### PR TITLE
Use the gcr.io/google_appengine/openjdk as base instead of openjdk:8

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ This repository contains the source for the `gcr.io/google_appengine/jetty` [doc
 The layout of this image is intended to mostly mimic the official [docker-jetty](https://github.com/appropriate/docker-jetty) image and unless otherwise noted, the official [docker-jetty documentation](https://github.com/docker-library/docs/tree/master/jetty) should apply.
 
 ## Building the Jetty image
-To build the image you need git, docker and maven installed and to have the openjdk:8
-image available in your docker repository:
+To build the image you need git, docker and maven installed:
 ```console
 git clone https://github.com/GoogleCloudPlatform/jetty-runtime.git
 cd jetty-runtime

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <docker.tag.short>${docker.tag.prefix}9.${jetty9.minor.version}</docker.tag.short>
     <docker.tag.long>${docker.tag.prefix}9.${jetty9.minor.version}-${maven.build.timestamp}</docker.tag.long>
 
-    <docker.openjdk.image>openjdk:8</docker.openjdk.image>
+    <docker.openjdk.image>gcr.io/google_appengine/openjdk</docker.openjdk.image>
   </properties>
 
   <developers>


### PR DESCRIPTION
Fixes #64 

@aslo 