### PR TITLE
Set securePort for HTTPS redirects to 443

### DIFF
--- a/jetty9-base/pom.xml
+++ b/jetty9-base/pom.xml
@@ -139,7 +139,29 @@
           </arguments>
         </configuration>
       </plugin>
-
+      <plugin>
+        <groupId>com.google.code.maven-replacer-plugin</groupId>
+        <artifactId>maven-replacer-plugin</artifactId>
+        <version>1.3.5</version>
+        <executions>
+            <execution>
+                <id>replaceTokens</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                    <goal>replace</goal>
+                </goals>
+            </execution>
+        </executions>
+        <configuration>
+            <file>target/jetty-base/start.d/server.ini</file>
+            <replacements>
+                <replacement>
+                    <token># jetty.httpConfig.securePort=8443</token>
+                    <value>jetty.httpConfig.securePort=443</value>
+                </replacement>
+            </replacements>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
@@ -159,6 +181,8 @@
           <appendAssemblyId>false</appendAssemblyId>
         </configuration>
       </plugin>
+
+
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Fixes #76.

This PR sets the securePort to 443 so that redirects can work when a non https request is received on a resource with a CONFIDENTIAL security constraint.

NB the technique of replacing jetty properties in .ini files using the maven-replacer-plugin is something that we can make more use of to customize the basic jetty distro for flex and eventually compat.