### PR TITLE
Issue #83 Use Jetty 9.4 configuration mechanism

### DIFF
--- a/jetty9-base/pom.xml
+++ b/jetty9-base/pom.xml
@@ -135,31 +135,8 @@
           <arguments>
             <argument>-jar</argument>
             <argument>../jetty-distribution-${jetty9.version}/start.jar</argument>
-            <argument>--add-to-startd=http,deploy,jsp,jstl,http-forwarded,resources,gae</argument>
+            <argument>--commands=${basedir}/src/main/jetty-config/jetty.commands</argument>
           </arguments>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>com.google.code.maven-replacer-plugin</groupId>
-        <artifactId>maven-replacer-plugin</artifactId>
-        <version>1.3.5</version>
-        <executions>
-            <execution>
-                <id>replaceTokens</id>
-                <phase>pre-integration-test</phase>
-                <goals>
-                    <goal>replace</goal>
-                </goals>
-            </execution>
-        </executions>
-        <configuration>
-            <file>target/jetty-base/start.d/server.ini</file>
-            <replacements>
-                <replacement>
-                    <token># jetty.httpConfig.securePort=8443</token>
-                    <value>jetty.httpConfig.securePort=443</value>
-                </replacement>
-            </replacements>
         </configuration>
       </plugin>
       <plugin>

--- a/jetty9-base/src/main/jetty-base/etc/gae.xml
+++ b/jetty9-base/src/main/jetty-base/etc/gae.xml
@@ -16,17 +16,7 @@
   -->
 
 <!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "http://www.eclipse.org/jetty/configure_9_0.dtd">
-
 <Configure id="Server" class="org.eclipse.jetty.server.Server">
-  <!-- =========================================================== -->
-  <!-- Ammend HttpConfig -->
-  <!-- =========================================================== -->
-  <Ref refid="httpConfig">
-    <Set name="headerCacheSize">
-      <Property name="jetty.httpConfig.headerCacheSize" default="512" />
-    </Set>
-  </Ref>
-
   <Ref refid="DeploymentManager">
     <Call name="addLifeCycleBinding">
       <Arg>
@@ -36,8 +26,4 @@
       </Arg>
     </Call>
   </Ref>
-
-  <!-- TODO remove when this has been added to jetty.xml -->
-  <Set name="stopTimeout"><Property name="jetty.server.stopTimeout" default="30000"/></Set>
-
 </Configure>

--- a/jetty9-base/src/main/jetty-base/modules/gae.mod
+++ b/jetty9-base/src/main/jetty-base/modules/gae.mod
@@ -1,5 +1,5 @@
 #
-# GAE Module for Jetty 9 MVM Image
+# GAE Module for Jetty 9 Flex Image
 #
 
 [depend]
@@ -14,17 +14,3 @@ etc/gae.xml
 
 [lib]
 lib/gae/*.jar
-
-[ini-template]
-
-## Google AppEngine Defaults
-jetty.httpConfig.outputAggregationSize=32768
-jetty.httpConfig.headerCacheSize=512
-
-jetty.httpConfig.sendServerVersion=true
-jetty.httpConfig.sendDateHeader=false
-
-#gae.httpPort=80
-#gae.httpsPort=443
-
-#jetty.server.stopTimeout=30000

--- a/jetty9-base/src/main/jetty-config/jetty.commands
+++ b/jetty9-base/src/main/jetty-config/jetty.commands
@@ -1,0 +1,12 @@
+--create-startd
+
+--add-to-start=server,webapp,http,deploy,jsp,jstl,http-forwarded,resources,gae
+
+jetty.httpConfig.outputAggregationSize=32768
+jetty.httpConfig.headerCacheSize=512
+jetty.httpConfig.sendServerVersion=true
+jetty.httpConfig.sendDateHeader=false
+
+jetty.server.stopTimeout=30000
+
+jetty.httpConfig.securePort=443

--- a/pom.xml
+++ b/pom.xml
@@ -34,13 +34,12 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.build.timestamp.format>yyyy-MM-dd_HH_mm</maven.build.timestamp.format>
     <appengine.api.version>1.9.40</appengine.api.version>
-    <jetty9.minor.version>3</jetty9.minor.version>
-    <jetty9.dot.version>8</jetty9.dot.version>
-    <jetty9.version>9.${jetty9.minor.version}.${jetty9.dot.version}.v20160314</jetty9.version>
+    <jetty9.minor.version>4</jetty9.minor.version>
+    <jetty9.dot.version>0</jetty9.dot.version>
+    <jetty9.version>9.${jetty9.minor.version}.${jetty9.dot.version}.RC3</jetty9.version>
     <docker.tag.prefix></docker.tag.prefix>
     <docker.tag.short>${docker.tag.prefix}9.${jetty9.minor.version}</docker.tag.short>
     <docker.tag.long>${docker.tag.prefix}9.${jetty9.minor.version}-${maven.build.timestamp}</docker.tag.long>
-
     <docker.openjdk.image>gcr.io/google_appengine/openjdk:8-2016-12-01_18_57</docker.openjdk.image>
   </properties>
 


### PR DESCRIPTION
Implements #83 by:
- using the new mechanism to expand properties from the command line into ini templates
- using the new mechanism to put the command line in a file, to externalize configuration from the pom.xml 
