### PR TITLE
Cleanup of jetty user and /app symlink

### DIFF
--- a/jetty9/pom.xml
+++ b/jetty9/pom.xml
@@ -28,6 +28,11 @@
   <artifactId>jetty9</artifactId>
   <packaging>pom</packaging>
 
+  <properties>
+    <jetty.home>/opt/jetty-distribution-${jetty9.version}</jetty.home>
+    <jetty.base>/var/lib/jetty</jetty.base>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>com.google.cloud.runtimes</groupId>

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -26,18 +26,17 @@ ENV GAE_IMAGE_LABEL ${docker.tag.long}
 # Create Jetty Home
 ENV JETTY_HOME ${jetty.home}
 ENV PATH $JETTY_HOME/bin:$PATH
-ENV TMPDIR /tmp/jetty
 ADD jetty-distribution.tar.gz $JETTY_HOME/..
-RUN mkdir $TMPDIR \
- && chown -R jetty:jetty $JETTY_HOME $TMPDIR
+RUN chown -R jetty:jetty $JETTY_HOME
 
 # Create Jetty Base
 ENV JETTY_BASE ${jetty.base}
+ENV TMPDIR /tmp/jetty
 ADD jetty-base $JETTY_BASE
 WORKDIR $JETTY_BASE
-RUN mkdir webapps \
+RUN mkdir webapps $TMPDIR \
  && java -jar $JETTY_HOME/start.jar --add-to-start=setuid \
- && chown -R jetty:jetty $JETTY_BASE
+ && chown -R jetty:jetty $JETTY_BASE $TMPDIR
 
 # Start Jetty directly
 COPY docker-entrypoint.bash /

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -24,24 +24,24 @@ ENV GAE_IMAGE_NAME jetty
 ENV GAE_IMAGE_LABEL ${docker.tag.long}
 
 # Create Jetty Home
-ENV JETTY_HOME /usr/local/jetty
+ENV JETTY_HOME ${jetty.home}
 ENV PATH $JETTY_HOME/bin:$PATH
 ENV TMPDIR /tmp/jetty
-ADD jetty-distribution.tar.gz /usr/local/
-RUN mv /usr/local/jetty-distribution-* $JETTY_HOME \
- && chown -R jetty:jetty $JETTY_HOME
+ADD jetty-distribution.tar.gz $JETTY_HOME/..
+RUN mkdir $TMPDIR \
+ && chown -R jetty:jetty $JETTY_HOME $TMPDIR
 
 # Create Jetty Base
-ENV JETTY_BASE /var/lib/jetty
+ENV JETTY_BASE ${jetty.base}
 ADD jetty-base $JETTY_BASE
 WORKDIR $JETTY_BASE
-RUN mkdir webapps /tmp/jetty \
+RUN mkdir webapps \
  && java -jar $JETTY_HOME/start.jar --add-to-start=setuid \
- && chown -R jetty:jetty /tmp/jetty $JETTY_BASE
+ && chown -R jetty:jetty $JETTY_BASE
 
 # Start Jetty directly
 COPY docker-entrypoint.bash /
-RUN chmod +x /docker-entrypoint.bash
+RUN chmod +rx /docker-entrypoint.bash
 
 EXPOSE 8080
-CMD ["java","-Djetty.base=/var/lib/jetty","-jar","/usr/local/jetty/start.jar"]
+CMD ["java","-Djetty.base=${jetty.base}","-jar","${jetty.home}/start.jar"]

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -18,7 +18,9 @@ FROM ${docker.openjdk.image}
 RUN groupadd -r jetty \
  && useradd -r -g jetty jetty \
  && apt-get -q update \
- && apt-get -y -q --no-install-recommends install sudo 
+ && apt-get -y -q --no-install-recommends install sudo \
+ && apt-get clean \
+ && rm /var/lib/apt/lists/*_*
 
 # Create env vars to identify image
 ENV JETTY_VERSION ${jetty9.version}

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -35,14 +35,15 @@ RUN mv /usr/local/jetty-distribution-* $JETTY_HOME \
 ENV JETTY_BASE /var/lib/jetty
 ADD jetty-base $JETTY_BASE
 WORKDIR $JETTY_BASE
-RUN java -jar $JETTY_HOME/start.jar --add-to-startd=setuid \
- && chown -R jetty:jetty $JETTY_BASE \
- && mkdir /tmp/jetty && chown -R jetty:jetty /tmp/jetty \
- && ln -s $JETTY_BASE/webapps/root /app
+RUN mkdir webapps /tmp/jetty \
+ && chown -R jetty:jetty /tmp/jetty $JETTY_BASE
 
 # Start Jetty directly
 COPY docker-entrypoint.bash /
 RUN chmod +x /docker-entrypoint.bash
+
+# Use the Jetty USER
+USER jetty
 
 EXPOSE 8080
 CMD ["java","-Djetty.base=/var/lib/jetty","-jar","/usr/local/jetty/start.jar"]

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -16,7 +16,9 @@ FROM ${docker.openjdk.image}
 
 # create jetty group and user
 RUN groupadd -r jetty \
- && useradd -r -g jetty jetty
+ && useradd -r -g jetty jetty \
+ && apt-get -q update \
+ && apt-get -y -q --no-install-recommends install sudo 
 
 # Create env vars to identify image
 ENV JETTY_VERSION ${jetty9.version}
@@ -41,9 +43,6 @@ RUN mkdir webapps /tmp/jetty \
 # Start Jetty directly
 COPY docker-entrypoint.bash /
 RUN chmod +x /docker-entrypoint.bash
-
-# Use the Jetty USER
-USER jetty
 
 EXPOSE 8080
 CMD ["java","-Djetty.base=/var/lib/jetty","-jar","/usr/local/jetty/start.jar"]

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -16,11 +16,7 @@ FROM ${docker.openjdk.image}
 
 # create jetty group and user
 RUN groupadd -r jetty \
- && useradd -r -g jetty jetty \
- && apt-get -q update \
- && apt-get -y -q --no-install-recommends install sudo \
- && apt-get clean \
- && rm /var/lib/apt/lists/*_*
+ && useradd -r -g jetty jetty
 
 # Create env vars to identify image
 ENV JETTY_VERSION ${jetty9.version}
@@ -40,6 +36,7 @@ ENV JETTY_BASE /var/lib/jetty
 ADD jetty-base $JETTY_BASE
 WORKDIR $JETTY_BASE
 RUN mkdir webapps /tmp/jetty \
+ && java -jar $JETTY_HOME/start.jar --add-to-start=setuid \
  && chown -R jetty:jetty /tmp/jetty $JETTY_BASE
 
 # Start Jetty directly

--- a/jetty9/src/main/docker/docker-entrypoint.bash
+++ b/jetty9/src/main/docker/docker-entrypoint.bash
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# Switch user to jetty
-if [ "$UID" = 0 ] ; then
-  exec sudo -HEu jetty -- "$0" "$@"
-fi
-
 # default jetty arguments
 DEFAULT_ARGS="-Djetty.base=$JETTY_BASE -jar $JETTY_HOME/start.jar"
 
@@ -16,6 +11,7 @@ if [ -e "$ROOT_WAR" ]; then
   # Unpack it only if $ROOT_DIR doesn't exist or the root is older than the war.
   if [ -e "$ROOT_WAR" -a \( \( ! -e "$ROOT_DIR" \) -o \( "$ROOT_DIR" -ot "$ROOT_WAR" \) \) ]; then
     unzip $ROOT_WAR -d $ROOT_DIR
+    chown -R jetty:jetty $ROOT_DIR
   fi
 fi
 

--- a/jetty9/src/main/docker/docker-entrypoint.bash
+++ b/jetty9/src/main/docker/docker-entrypoint.bash
@@ -5,14 +5,19 @@ DEFAULT_ARGS="-Djetty.base=$JETTY_BASE -jar $JETTY_HOME/start.jar"
 
 # Unpack a WAR app (if present) beforehand so that Stackdriver Debugger
 # can load it. This should be done before the JVM for Jetty starts up.
-WEBAPP_WAR=$JETTY_BASE/webapps/root.war
-WEBAPP_ROOT=$JETTY_BASE/webapps/root
-if [ -e "$WEBAPP_WAR" ]; then
-  # Unpack it only if $WEBAPP_ROOT doesn't exist or the root is older than the war.
-  if [ -e "$WEBAPP_WAR" -a \( \( ! -e "$WEBAPP_ROOT" \) -o \( "$WEBAPP_ROOT" -ot "$WEBAPP_WAR" \) \) ]; then
-    unzip $WEBAPP_WAR -d $WEBAPP_ROOT
-    chown -R jetty.jetty $WEBAPP_ROOT
+ROOT_WAR=$JETTY_BASE/webapps/root.war
+ROOT_DIR=$JETTY_BASE/webapps/root
+if [ -e "$ROOT_WAR" ]; then
+  # Unpack it only if $ROOT_DIR doesn't exist or the root is older than the war.
+  if [ -e "$ROOT_WAR" -a \( \( ! -e "$ROOT_DIR" \) -o \( "$ROOT_DIR" -ot "$ROOT_WAR" \) \) ]; then
+    unzip $ROOT_WAR -d $ROOT_DIR
+    chown -R jetty.jetty $ROOT_DIR
   fi
+fi
+
+# If webapp root not available, then try /app as used by gcloud maven plugin
+if [ ! -e "$ROOT_DIR" -a -d /app ]; then
+  ln -s /app "$ROOT_DIR"
 fi
 
 # If the passed arguments start with the java command

--- a/jetty9/src/main/docker/docker-entrypoint.bash
+++ b/jetty9/src/main/docker/docker-entrypoint.bash
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Switch user to jetty
+if [ "$UID" = 0 ] ; then
+  exec sudo -HEu jetty -- "$0" "$@"
+fi
+
 # default jetty arguments
 DEFAULT_ARGS="-Djetty.base=$JETTY_BASE -jar $JETTY_HOME/start.jar"
 
@@ -11,7 +16,6 @@ if [ -e "$ROOT_WAR" ]; then
   # Unpack it only if $ROOT_DIR doesn't exist or the root is older than the war.
   if [ -e "$ROOT_WAR" -a \( \( ! -e "$ROOT_DIR" \) -o \( "$ROOT_DIR" -ot "$ROOT_WAR" \) \) ]; then
     unzip $ROOT_WAR -d $ROOT_DIR
-    chown -R jetty.jetty $ROOT_DIR
   fi
 fi
 
@@ -40,5 +44,4 @@ if ! type "$1" &>/dev/null; then
 fi
 
 exec "$@"
-
 


### PR DESCRIPTION
Fixes #85 by
- removed the symlink that is created in the Dockerfile
- updated docker-entrypoint.bash to look for content in app and only create the symlink if needed
- removed the setuid module
- add USER jetty to the Dockerfile