### PR TITLE
Turn on local tests by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <docker.tag.prefix></docker.tag.prefix>
     <docker.tag.short>${docker.tag.prefix}9.${jetty9.minor.version}</docker.tag.short>
     <docker.tag.long>${docker.tag.prefix}9.${jetty9.minor.version}-${maven.build.timestamp}</docker.tag.long>
-    <docker.openjdk.image>gcr.io/google_appengine/openjdk:8-2016-12-08_19_56</docker.openjdk.image>
+    <docker.openjdk.image>gcr.io/google-appengine/openjdk:8-2016-12-08_19_56</docker.openjdk.image>
   </properties>
 
   <developers>
@@ -129,7 +129,7 @@
           <version>2.10</version>
         </plugin>
 
-	<plugin>
+	    <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
           <version>3.0.1</version>
@@ -286,6 +286,9 @@
   <profiles>
     <profile>
       <id>tests</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <modules>
         <module>tests</module>
       </modules>

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,7 +19,7 @@ At the top level of the project.
 > mvn install
 ```
 
-This will run a normal build cycle for the jetty-runtime project.  No tests are expected to run during this step.  The docker image being built will be available to use in later local testing steps.  To see what tags are available use the following docker command:
+This will run a normal build cycle for the jetty-runtime project.  Only local container tests are expected to run during this step.  The docker image being built will be available to use in later steps.  To see what tags are available use the following docker command:
 
 ```
 > docker images
@@ -55,7 +55,7 @@ From the jetty-runtime/tests directory:
 > mvn install -Plocal -Djetty.test.image=jetty:9.4
 ```
 
-This will activate the 'local' profile and enable testing.  The tests activated under this profile will make use of the locally installed image and tag referenced in the jetty.test.image property.  The spotify docker-maven-plugin is used to build the test docker container and the io.fabric8 docker plugin is used to manage the integration test lifecycle. Local tests may have a smaller scope as they are not intended to the complete Google Flex environment.  Local testing is intended to test and validate configuration of Jetty and basic environment. 
+This will activate the 'local' profile and enable testing.  The tests activated under this profile will make use of the locally installed image and tag referenced in the jetty.test.image property, which defaults to jetty:9.4.  The spotify docker-maven-plugin is used to build the test docker container and the io.fabric8 docker plugin is used to manage the integration test lifecycle. Local tests may have a smaller scope as they are not intended to the complete Google Flex environment.  Local testing is intended to test and validate configuration of Jetty and basic environment.
 
 Remote Testing
 =====
@@ -87,7 +87,7 @@ Requirements:
 Conventions:
 ====
 
-* testing is disabled by default, activated via -Plocal or -Premote
+* remote testing is disabled by default, activated via -Premote
 * local and remote testing are mutually exclusive
 * local integration tests end in ‘LocalIntegrationTest’
 * remote integration tests end in ‘RemoteIntegrationTest’

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -29,6 +29,7 @@
   <packaging>pom</packaging>
   <properties>
     <checkstyle.skip>false</checkstyle.skip>
+    <jetty.test.image>jetty:${docker.tag.short}</jetty.test.image>
   </properties>
   <modules>
     <module>gcloud-testing-core</module>
@@ -77,6 +78,9 @@
   <profiles>
     <profile>
       <id>local</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>

--- a/tests/test-war-smoke/pom.xml
+++ b/tests/test-war-smoke/pom.xml
@@ -66,6 +66,9 @@
   <profiles>
     <profile>
       <id>local</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
I'm exploring the option of having local tests run by default, since they run so quickly.
One concern I have is the statement we have in the design doc saying "local and remote testing are mutually exclusive". I'm not sure if this has to be the case. @jmcc0nn3ll 