### PR TITLE
Resolve #109 local and remote testing works, -Ptest.remote,test.local

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,16 +61,13 @@ script:
   # execute remote tests
   - |
     if $DO_REMOTE; then
-      # deploy image to gcr
-      image=gcr.io/travis-app-maven-plugin/jetty_test:`date +%s`
-      docker tag jetty:9.4 $image
       # do the remote test
-      gcloud docker -q -- push $image && mvn clean verify -Ptest.local,test.remote,test.remote.deploy,test.remote.clean -Djetty.test.image=$image -B -q
+      mvn clean verify -Ptest.local,test.remote,test.remote.deploy,test.remote.clean -B -q
     fi
 
-after_script:
-  - |
-    if $DO_REMOTE; then
-      # cleanup deployed image
-      gcloud beta container images delete gcr.io/travis-app-maven-plugin/jetty_test@ -q
-    fi
+#after_script:
+#  - |
+#    if $DO_REMOTE; then
+#      # cleanup deployed image
+#      gcloud beta container images delete gcr.io/travis-app-maven-plugin/jetty_test@ -q
+#    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
       image=gcr.io/travis-app-maven-plugin/jetty_test:`date +%s`
       docker tag jetty:9.4 $image
       # do the remote test
-      gcloud docker -q -- push $image && mvn clean verify -Ptest.remote,test.local -Djetty.test.image=$image -B -q
+      gcloud docker -q -- push $image && mvn clean verify -Ptest.local,test.remote,test.remote.deploy,test.remote.clean -Djetty.test.image=$image -B -q
     fi
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
       image=gcr.io/travis-app-maven-plugin/jetty:`date +%s`
       docker tag jetty:9.4 $image
       # do the remote test
-      gcloud docker -q -- push $image && mvn clean verify -Ptest.remote -Djetty.test.image=$image -B -q
+      gcloud docker -q -- push $image && mvn clean verify -Ptest.remote,test.local -Djetty.test.image=$image -B -q
     fi
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,8 +57,7 @@ install:
 
 script:
   # execute regular local build
-  - mvn clean verify
-  #- mvn clean verify -B -V -q
+  - mvn clean verify -B -V -q
   # execute remote tests
   - |
     if $DO_REMOTE; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,13 +61,6 @@ script:
   # execute remote tests
   - |
     if $DO_REMOTE; then
-      # do the remote test
+      # do the remote test, will use default image setting and should clean up remote test image resources
       mvn clean verify -Ptest.local,test.remote,test.remote.deploy,test.remote.clean -B -q
     fi
-
-#after_script:
-#  - |
-#    if $DO_REMOTE; then
-#      # cleanup deployed image
-#      gcloud beta container images delete gcr.io/travis-app-maven-plugin/jetty_test@ -q
-#    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,8 @@ install:
 
 script:
   # execute regular local build
-  - mvn clean verify -B -V -q
+  - mvn clean verify
+  #- mvn clean verify -B -V -q
   # execute remote tests
   - |
     if $DO_REMOTE; then

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>1.4.0</version>
+          <version>1.5.0</version>
         </plugin>
 
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.build.timestamp.format>yyyy-MM-dd_HH_mm</maven.build.timestamp.format>
+    <maven.build.timestamp.format>yyyy-MM-dd-HH-mm</maven.build.timestamp.format>
     <jetty9.minor.version>4</jetty9.minor.version>
     <jetty9.dot.version>0</jetty9.dot.version>
     <jetty9.version>9.${jetty9.minor.version}.${jetty9.dot.version}.v20161208</jetty9.version>

--- a/pom.xml
+++ b/pom.xml
@@ -123,35 +123,35 @@
             </execution>
           </executions>
         </plugin>
-        
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <version>2.10</version>
         </plugin>
-
 	      <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
           <version>3.0.1</version>
         </plugin>
-
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.2</version>
+          <version>3.5.1</version>
           <configuration>
             <source>1.8</source>
             <target>1.8</target>
           </configuration>
         </plugin>
-
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>1.5.0</version>
         </plugin>
-
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>properties-maven-plugin</artifactId>
+          <version>1.0.0</version>
+        </plugin>
         <plugin>
           <groupId>com.spotify</groupId>
           <artifactId>docker-maven-plugin</artifactId>
@@ -165,8 +165,7 @@
             <useSystemClassLoader>false</useSystemClassLoader>
           </configuration>
         </plugin>
-
-       <plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
           <version>2.4</version>
@@ -182,31 +181,26 @@
             </execution>
           </executions>
         </plugin>
-
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
           <version>2.5.2</version>
         </plugin>
-
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>2.5</version>
         </plugin>
-
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
           <version>1.8</version>
         </plugin>
-
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.8.2</version>
         </plugin>
-
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>

--- a/tests/README.md
+++ b/tests/README.md
@@ -36,7 +36,11 @@ In order to make these images available for remote testing you can use the follo
 > gcloud docker push gcr.io/{project}/jetty:9.4 
 ```
 
-This will take the local artifacts and make them available for remote testing (or general usage for the given {project}).
+This will take the local artifacts and make them available for remote testing (or general usage for the given {project}).  Additionally when using test.remote the test.deploy profile can perform the tag and push.
+
+```
+> mvn -Ptest.remote,test.remote.deploy install
+```
 
 Local testing can be disabled via as follows:
 
@@ -72,9 +76,13 @@ Again from the jetty-runtime/tests directory:
 > mvn install -Ptest.remote -Djetty.test.image=gcr.io/{project}/jetty:9.4
 ```
 
-This will activate the remote testing profile.. Under this scenario, for each test artifact the appengine-maven-plugin is used to deploy an instance of the application to the Google Flexible environment and then run appropriate test cases.  The containers for each webapp will be built through using the cloud builder mechanism.  This means the image to be tested (as referenced in the jetty.test.image property) will need to be deployed to the appropriate gcr.io location.  Remote testing can make use of the entire scope of services available to Google Flex.  
+This will activate the remote testing profile. Under this scenario, for each test artifact the appengine-maven-plugin is used to deploy an instance of the application to the Google Flexible environment and then run appropriate test cases.  The containers for each webapp will be built through using the cloud builder mechanism.  This means the image to be tested (as referenced in the jetty.test.image property) will need to be deployed to the appropriate gcr.io location.  Remote testing can make use of the entire scope of services available to Google Flex.  
 
 It is possible to run local and remote testing at the same time by using -Ptest.remote,test.local however it is important to note that the jetty.test.image is required to point to an image in gcr.io and local testing will use this same image.
+
+The default value for the jetty.test.image property when using the test.remote property is 'gcr.io/{project}/jetty:9.4'.
+
+The test.remote.clean profile will remove the remote container that is deployed via the test.remote.deploy profile.
 
 Test Case Requirements and Conventions
 ===
@@ -102,6 +110,7 @@ Conventions:
 * jetty.test.image default for local is 'jetty:${docker.tag.short}'
 * remote testing is enabled via -Ptest.remote
 * local testing is turned off by -P-test.local
+* local and remote testing can both be active but remote image is always used
 * local and remote testing can both be active but remote image is always used
 * a custom LocalRemoteTestRunner junit test runner is used to find tests to run
 * test classes should extend the AbstractIntegrationTest from gcloud-testing-core

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,7 +25,7 @@ This will run a normal build cycle for the jetty-runtime project.  Local tests a
 > docker images
 REPOSITORY                        TAG                        IMAGE ID            CREATED             SIZE
 jetty                             9.4                        b6cbab53c076        47 hours ago        359.2 MB
-jetty                             9.4-2016-12-13_17_02       b6cbab53c076        47 hours ago        359.2 MB
+jetty                             9.4-2016-12-13-17-02       b6cbab53c076        47 hours ago        359.2 MB
 jetty                             latest                     b6cbab53c076        47 hours ago        359.2 MB
 ```
 
@@ -36,7 +36,7 @@ In order to make these images available for remote testing you can use the follo
 > gcloud docker push gcr.io/{project}/jetty:9.4 
 ```
 
-This will take the local artifacts and make them available for remote testing (or general usage for the given {project}).  Additionally when using test.remote the test.deploy profile can perform the tag and push.
+This will take the local artifacts and make them available for remote testing (or general usage for the given {project}).  Additionally when using test.remote the test.remote.deploy profile can perform the tag and push.
 
 ```
 > mvn -Ptest.remote,test.remote.deploy install
@@ -76,11 +76,11 @@ Again from the jetty-runtime/tests directory:
 > mvn install -Ptest.remote -Djetty.test.image=gcr.io/{project}/jetty:9.4
 ```
 
-This will activate the remote testing profile. Under this scenario, for each test artifact the appengine-maven-plugin is used to deploy an instance of the application to the Google Flexible environment and then run appropriate test cases.  The containers for each webapp will be built through using the cloud builder mechanism.  This means the image to be tested (as referenced in the jetty.test.image property) will need to be deployed to the appropriate gcr.io location.  Remote testing can make use of the entire scope of services available to Google Flex.  
+This will activate the remote testing profile. Under this scenario, for each test artifact the appengine-maven-plugin is used to deploy an instance of the application to the Google Flexible environment and then run appropriate test cases.  The containers for each webapp will be built through using the cloud builder mechanism available in GCP.  This means the image to be tested (as referenced in the jetty.test.image property) will need to be deployed to the appropriate gcr.io location.  Remote testing can make use of the entire scope of services available to Google Flex.  
 
 It is possible to run local and remote testing at the same time by using -Ptest.remote,test.local however it is important to note that the jetty.test.image is required to point to an image in gcr.io and local testing will use this same image.
 
-The default value for the jetty.test.image property when using the test.remote property is 'gcr.io/{project}/jetty:9.4'.
+The default value for the jetty.test.image property when using the test.remote property is 'gcr.io/{project}/jetty:{docker.tag.long}'.
 
 The test.remote.clean profile will remove the remote container that is deployed via the test.remote.deploy profile.
 
@@ -110,7 +110,6 @@ Conventions:
 * jetty.test.image default for local is 'jetty:${docker.tag.short}'
 * remote testing is enabled via -Ptest.remote
 * local testing is turned off by -P-test.local
-* local and remote testing can both be active but remote image is always used
 * local and remote testing can both be active but remote image is always used
 * a custom LocalRemoteTestRunner junit test runner is used to find tests to run
 * test classes should extend the AbstractIntegrationTest from gcloud-testing-core

--- a/tests/README.md
+++ b/tests/README.md
@@ -72,9 +72,9 @@ Again from the jetty-runtime/tests directory:
 > mvn install -Ptest.remote -Djetty.test.image=gcr.io/{project}/jetty:9.4
 ```
 
-This will activate the remote testing profile and suppress local testing. Under this scenario, for each test artifact the appengine-maven-plugin is used to deploy an instance of the application to the Google Flexible environment and then run appropriate test cases.  The containers for each webapp will be built through using the cloud builder mechanism.  This means the image to be tested (as referenced in the jetty.test.image property) will need to be deployed to the appropriate gcr.io location.  Remote testing can make use of the entire scope of services available to Google Flex.  
+This will activate the remote testing profile.. Under this scenario, for each test artifact the appengine-maven-plugin is used to deploy an instance of the application to the Google Flexible environment and then run appropriate test cases.  The containers for each webapp will be built through using the cloud builder mechanism.  This means the image to be tested (as referenced in the jetty.test.image property) will need to be deployed to the appropriate gcr.io location.  Remote testing can make use of the entire scope of services available to Google Flex.  
 
-
+It is possible to run local and remote testing at the same time by using -Ptest.remote,test.local however it is important to note that the jetty.test.image is required to point to an image in gcr.io and local testing will use this same image.
 
 Test Case Requirements and Conventions
 ===
@@ -102,7 +102,7 @@ Conventions:
 * jetty.test.image default for local is 'jetty:${docker.tag.short}'
 * remote testing is enabled via -Ptest.remote
 * local testing is turned off by -P-test.local
-* local and remote testing are mutually exclusive
+* local and remote testing can both be active but remote image is always used
 * a custom LocalRemoteTestRunner junit test runner is used to find tests to run
 * test classes should extend the AbstractIntegrationTest from gcloud-testing-core
 * local only integration tests have the @LocalOnly annotation

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -30,7 +30,7 @@
   <properties>
     <checkstyle.skip>false</checkstyle.skip>
     <!-- default image name for local tests -->
-    <jetty.test.image>jetty:${docker.tag.short}</jetty.test.image>
+    <jetty.test.image>jetty:${docker.tag.long}</jetty.test.image>
   </properties>
   <modules>
     <module>gcloud-testing-core</module>
@@ -91,16 +91,34 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.19.1</version>
           <configuration>
             <excludes>
               <exclude>**/*IntegrationTest.java</exclude>
             </excludes>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>io.fabric8</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
+          <version>0.17.2</version>
+          <configuration>
+            <images>
+              <image>
+                <name>${project.artifactId}:${project.version}</name>
+                <alias>${project.artifactId}</alias>
+                <run>
+                  <ports>
+                    <port>${local.app.port}:8080</port>
+                  </ports>
+                </run>
+              </image>
+            </images>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
+      <!-- ensure no artifacts are published during deploy -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -40,16 +40,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>com.google.cloud.tools</groupId>
-          <artifactId>appengine-maven-plugin</artifactId>
-          <configuration>
-            <deploy.project>${app.deploy.project}</deploy.project>
-            <deploy.version>${maven.build.timestamp}</deploy.version>
-            <deploy.promote>false</deploy.promote>
-            <dockerDirectory>${project.build.directory}/docker</dockerDirectory>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>com.spotify</groupId>
           <artifactId>docker-maven-plugin</artifactId>
           <configuration>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -40,24 +40,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>com.spotify</groupId>
-          <artifactId>docker-maven-plugin</artifactId>
-          <configuration>
-            <imageName>${project.artifactId}</imageName>
-            <imageTags>
-              <imageTag>${project.version}</imageTag>
-            </imageTags>
-            <dockerDirectory>${project.build.directory}/docker</dockerDirectory>
-            <resources>
-              <resource>
-                <targetPath>/</targetPath>
-                <directory>${project.build.directory}</directory>
-                <include>${project.build.finalName}.war</include>
-              </resource>
-            </resources>
-          </configuration>
-        </plugin>
-        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>2.19.1</version>
@@ -90,7 +72,7 @@
         <plugin>
           <groupId>io.fabric8</groupId>
           <artifactId>docker-maven-plugin</artifactId>
-          <version>0.17.2</version>
+          <version>0.19.0</version>
           <configuration>
             <images>
               <image>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -129,6 +129,11 @@
         <targetPath>${project.build.directory}/appengine-staging</targetPath>
       </resource>
       <resource>
+        <directory>src/main/docker</directory>
+        <filtering>true</filtering>
+        <targetPath>${project.build.directory}/appengine-staging</targetPath>
+      </resource>
+      <resource>
         <directory>src/main/resources</directory>
         <filtering>true</filtering>
         <targetPath>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -29,6 +29,7 @@
   <packaging>pom</packaging>
   <properties>
     <checkstyle.skip>false</checkstyle.skip>
+    <!-- default image name for local tests -->
     <jetty.test.image>jetty:${docker.tag.short}</jetty.test.image>
   </properties>
   <modules>
@@ -38,6 +39,34 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>com.google.cloud.tools</groupId>
+          <artifactId>appengine-maven-plugin</artifactId>
+          <configuration>
+            <deploy.project>${app.deploy.project}</deploy.project>
+            <deploy.version>${maven.build.timestamp}</deploy.version>
+            <deploy.promote>false</deploy.promote>
+            <dockerDirectory>${project.build.directory}/docker</dockerDirectory>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>com.spotify</groupId>
+          <artifactId>docker-maven-plugin</artifactId>
+          <configuration>
+            <imageName>${project.artifactId}</imageName>
+            <imageTags>
+              <imageTag>${project.version}</imageTag>
+            </imageTags>
+            <dockerDirectory>${project.build.directory}/docker</dockerDirectory>
+            <resources>
+              <resource>
+                <targetPath>/</targetPath>
+                <directory>${project.build.directory}</directory>
+                <include>${project.build.finalName}.war</include>
+              </resource>
+            </resources>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
@@ -54,10 +83,32 @@
             <includes>
               <include>%regex[.*IntegrationTest.*]</include>
             </includes>
+            <systemPropertyVariables>
+              <app.deploy.port>${local.app.port}</app.deploy.port>
+            </systemPropertyVariables>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.19.1</version>
+          <configuration>
+            <excludes>
+              <exclude>**/*IntegrationTest.java</exclude>
+            </excludes>
           </configuration>
         </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
     <resources>
       <resource>
         <directory>src/main/docker</directory>
@@ -78,65 +129,4 @@
       </resource>
     </resources>
   </build>
-  <profiles>
-    <profile>
-      <id>test.local</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-        <property>
-          <name>test.mode</name>
-          <value>local</value>
-        </property>
-      </activation>
-      <!--
-      <properties>
-        <test.mode>local</test.mode>
-      </properties>
-      -->
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.19.1</version>
-            <configuration>
-              <skipTests>false</skipTests>
-              <systemPropertyVariables>
-                <test.mode>local</test.mode>
-              </systemPropertyVariables>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>test.remote</id>
-      <activation>
-        <property>
-          <name>test.mode</name>
-          <value>remote</value>
-        </property>
-      </activation>
-      <properties>
-        <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
-        <gcloud-projectId-file>${project.build.directory}/gcloud-projectid.properties
-        </gcloud-projectId-file>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.19.1</version>
-            <configuration>
-              <skipTests>false</skipTests>
-              <systemPropertyVariables>
-                <test.mode>remote</test.mode>
-              </systemPropertyVariables>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/tests/test-war-smoke/pom.xml
+++ b/tests/test-war-smoke/pom.xml
@@ -173,24 +173,30 @@
               </execution>
             </executions>
           </plugin>
-          <!-- runs lifecycle to stage and deploy a remote service to test -->
-          <plugin>
-            <groupId>com.google.cloud.tools</groupId>
-            <artifactId>appengine-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>deploy-integration-test</id>
-                <phase>pre-integration-test</phase>
-                <goals>
-                  <goal>deploy</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
             <executions>
+              <!-- deploy the service -->
+              <execution>
+                <id>deploy-remote-service</id>
+                <phase>pre-integration-test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <workingDirectory>${project.build.directory}/appengine-staging</workingDirectory>
+                  <executable>gcloud</executable>
+                  <arguments>
+                    <argument>--quiet</argument>
+                    <argument>app</argument>
+                    <argument>deploy</argument>
+                    <argument>app.yaml</argument>
+                    <argument>--version</argument>
+                    <argument>${maven.build.timestamp}</argument>
+                  </arguments>
+                </configuration>
+              </execution>
               <!-- remove the service from 'deploy-integration-test' -->
               <execution>
                 <id>cleanup-remote-service</id>

--- a/tests/test-war-smoke/pom.xml
+++ b/tests/test-war-smoke/pom.xml
@@ -131,6 +131,19 @@
                   </target>
                 </configuration>
               </execution>
+              <execution>
+                <id>copy-deploy-artifact</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <copy file="${project.build.directory}/${project.artifactId}-${project.version}.war"
+                          todir="${project.build.directory}/appengine-staging/"/>
+                  </target>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
           <plugin>

--- a/tests/test-war-smoke/pom.xml
+++ b/tests/test-war-smoke/pom.xml
@@ -22,6 +22,7 @@
     <groupId>com.google.cloud.runtimes.tests</groupId>
     <artifactId>tests-parent</artifactId>
     <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
   <artifactId>test-war-smoke</artifactId>
   <packaging>war</packaging>
@@ -51,16 +52,6 @@
           <target>1.8</target>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
-        <configuration>
-          <excludes>
-            <exclude>**/*IntegrationTest.java</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
   <profiles>
@@ -68,50 +59,28 @@
       <id>test.local</id>
       <activation>
         <activeByDefault>true</activeByDefault>
-        <property>
-          <name>test.mode</name>
-          <value>local</value>
-        </property>
       </activation>
       <build>
         <plugins>
           <plugin>
-            <groupId>com.spotify</groupId>
-            <artifactId>docker-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>build</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>build</goal>
-                </goals>
-                <configuration>
-                  <imageName>${project.artifactId}</imageName>
-                  <imageTags>
-                    <imageTag>${project.version}</imageTag>
-                  </imageTags>
-                  <dockerDirectory>${project.build.directory}/docker
-                  </dockerDirectory>
-                  <resources>
-                    <resource>
-                      <targetPath>/</targetPath>
-                      <directory>${project.build.directory}</directory>
-                      <include>${project.build.finalName}.war</include>
-                    </resource>
-                  </resources>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>2.19.1</version>
-            <configuration>
-              <systemPropertyVariables>
-                <app.deploy.port>${app.deploy.port}</app.deploy.port>
-              </systemPropertyVariables>
-            </configuration>
+            <executions>
+              <execution>
+                <id>local-integration-test</id>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <skipTests>false</skipTests>
+                  <systemPropertyVariables>
+                    <test.mode>local</test.mode>
+                  </systemPropertyVariables>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
           <plugin>
             <groupId>io.fabric8</groupId>
@@ -124,7 +93,7 @@
                   <alias>test-war-smoke</alias>
                   <run>
                     <ports>
-                      <port>${app.deploy.port}:8080</port>
+                      <port>${local.app.port}:8080</port>
                     </ports>
                   </run>
                 </image>
@@ -152,12 +121,13 @@
     </profile>
     <profile>
       <id>test.remote</id>
-      <activation>
-        <property>
-          <name>test.mode</name>
-          <value>remote</value>
-        </property>
-      </activation>
+      <properties>
+        <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
+        <gcloud-projectId-file>${project.build.directory}/gcloud-projectid.properties
+        </gcloud-projectId-file>
+        <!-- remote tests require image in gcr.io -->
+        <jetty.test.image>gcr.io/${app.deploy.project}/jetty:${docker.tag.short}</jetty.test.image>
+      </properties>
       <build>
         <plugins>
           <plugin>
@@ -229,15 +199,22 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <version>2.19.1</version>
-            <configuration>
-              <systemPropertyVariables>
-                <app.deploy.project>${app.deploy.project}</app.deploy.project>
-                <app.deploy.version>${maven.build.timestamp}</app.deploy.version>
-              </systemPropertyVariables>
-            </configuration>
             <executions>
               <execution>
+                <id>remote-integration-test</id>
                 <phase>integration-test</phase>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+                <configuration>
+                  <skipTests>false</skipTests>
+                  <systemPropertyVariables>
+                    <test.mode>remote</test.mode>
+                    <app.deploy.project>${app.deploy.project}</app.deploy.project>
+                    <app.deploy.version>${maven.build.timestamp}</app.deploy.version>
+                  </systemPropertyVariables>
+                </configuration>
               </execution>
             </executions>
           </plugin>
@@ -251,12 +228,46 @@
                 <goals>
                   <goal>deploy</goal>
                 </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>tag-image</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>tag</goal>
+                </goals>
                 <configuration>
-                  <deploy.project>${app.deploy.project}</deploy.project>
-                  <deploy.version>${maven.build.timestamp}</deploy.version>
-                  <deploy.promote>false</deploy.promote>
-                  <dockerDirectory>${project.build.directory}/docker
-                  </dockerDirectory>
+                  <image>jetty:${docker.tag.short}</image>
+                  <newName>${jetty.test.image}</newName>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.5.0</version>
+            <executions>
+              <execution>
+                <id>deploy-remote-docker</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>gcloud</executable>
+                  <arguments>
+                    <argument>docker</argument>
+                    <argument>-q</argument>
+                    <argument>--</argument>
+                    <argument>push</argument>
+                    <argument>${jetty.test.image}</argument>
+                  </arguments>
                 </configuration>
               </execution>
             </executions>

--- a/tests/test-war-smoke/pom.xml
+++ b/tests/test-war-smoke/pom.xml
@@ -203,15 +203,15 @@
                     <argument>app</argument>
                     <argument>deploy</argument>
                     <argument>app.yaml</argument>
+                    <argument>--promote</argument>
                     <argument>--version</argument>
                     <argument>${maven.build.timestamp}</argument>
                   </arguments>
                 </configuration>
               </execution>
-              <!-- remove the service from 'deploy-integration-test' -->
-              <!--
+              <!-- stop the service from 'deploy-remote-service' -->
               <execution>
-                <id>cleanup-remote-service</id>
+                <id>stop-remote-service</id>
                 <phase>post-integration-test</phase>
                 <goals>
                   <goal>exec</goal>
@@ -219,15 +219,32 @@
                 <configuration>
                   <executable>gcloud</executable>
                   <arguments>
-                    <argument>- -quiet</argument>
+                    <argument>--quiet</argument>
                     <argument>app</argument>
                     <argument>versions</argument>
-                    <argument>delete</argument>
-                    <argument>${maven.build.timestamp}</argument> // this needs to be sha value of image
+                    <argument>stop</argument>
+                    <argument>${maven.build.timestamp}</argument>
                   </arguments>
                 </configuration>
               </execution>
-              -->
+              <!-- remove the service from 'deploy-remote-service' -->
+              <execution>
+                <id>delete-remote-service</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>gcloud</executable>
+                  <arguments>
+                    <argument>--quiet</argument>
+                    <argument>app</argument>
+                    <argument>versions</argument>
+                    <argument>delete</argument>
+                    <argument>${maven.build.timestamp}</argument>
+                  </arguments>
+                </configuration>
+              </execution>
             </executions>
           </plugin>
         </plugins>
@@ -298,14 +315,10 @@
                   <goal>exec</goal>
                 </goals>
                 <configuration>
-                  <executable>gcloud</executable>
+                  <executable>bash</executable>
                   <arguments>
-                    <argument>beta</argument>
-                    <argument>container</argument>
-                    <argument>images</argument>
-                    <argument>delete</argument>
-                    <argument>${jetty.test.image}</argument>
-                    <argument>-q</argument>
+                    <argument>-c</argument>
+                    <argument>gcloud beta container images delete `docker inspect --format='{{index .RepoDigests 0}}' ${jetty.test.image}` -q</argument>
                   </arguments>
                 </configuration>
               </execution>

--- a/tests/test-war-smoke/pom.xml
+++ b/tests/test-war-smoke/pom.xml
@@ -187,6 +187,37 @@
               </execution>
             </executions>
           </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
+              <!-- remove the service from 'deploy-integration-test' -->
+              <execution>
+                <id>cleanup-remote-service</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>gcloud</executable>
+                  <arguments>
+                    <argument>--quiet</argument>
+                    <argument>app</argument>
+                    <argument>versions</argument>
+                    <argument>delete</argument>
+                    <argument>${maven.build.timestamp}</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>test.remote.deploy</id>
+      <build>
+        <plugins>
           <!-- create tag for local docker image to push for remote use in test -->
           <plugin>
             <groupId>com.spotify</groupId>
@@ -227,24 +258,19 @@
                   </arguments>
                 </configuration>
               </execution>
-              <!-- remove the service from 'deploy-integration-test' -->
-              <execution>
-                <id>cleanup-remote-service</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <configuration>
-                  <executable>gcloud</executable>
-                  <arguments>
-                    <argument>--quiet</argument>
-                    <argument>app</argument>
-                    <argument>versions</argument>
-                    <argument>delete</argument>
-                    <argument>${maven.build.timestamp}</argument>
-                  </arguments>
-                </configuration>
-              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>test.remote.clean</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <executions>
               <!-- remove the remote image from 'deploy-remote-docker' -->
               <execution>
                 <id>cleanup-remote-image</id>
@@ -255,12 +281,12 @@
                 <configuration>
                   <executable>gcloud</executable>
                   <arguments>
-                    <argument>docker</argument>
-                    <argument>-q</argument>
-                    <argument>--</argument>
-                    <argument>rmi</argument>
-                    <argument>-f</argument>
+                    <argument>beta</argument>
+                    <argument>container</argument>
+                    <argument>images</argument>
+                    <argument>delete</argument>
                     <argument>${jetty.test.image}</argument>
+                    <argument>-q</argument>
                   </arguments>
                 </configuration>
               </execution>

--- a/tests/test-war-smoke/pom.xml
+++ b/tests/test-war-smoke/pom.xml
@@ -41,6 +41,37 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.spotify</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>build</id>
+            <phase>package</phase>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <imageName>${project.artifactId}</imageName>
+              <imageTags>
+                <imageTag>${project.version}</imageTag>
+              </imageTags>
+              <dockerDirectory>${project.build.directory}/docker</dockerDirectory>
+              <resources>
+                <resource>
+                  <targetPath>/</targetPath>
+                  <directory>${project.build.directory}</directory>
+                  <include>${project.build.finalName}.war</include>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
   <profiles>
     <profile>
       <id>test.local</id>

--- a/tests/test-war-smoke/pom.xml
+++ b/tests/test-war-smoke/pom.xml
@@ -203,7 +203,6 @@
                     <argument>app</argument>
                     <argument>deploy</argument>
                     <argument>app.yaml</argument>
-                    <argument>--promote</argument>
                     <argument>--version</argument>
                     <argument>${maven.build.timestamp}</argument>
                   </arguments>

--- a/tests/test-war-smoke/pom.xml
+++ b/tests/test-war-smoke/pom.xml
@@ -41,19 +41,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.5.1</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
   <profiles>
     <profile>
       <id>test.local</id>
@@ -65,7 +52,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.19.1</version>
             <executions>
               <execution>
                 <id>local-integration-test</id>
@@ -85,20 +71,6 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>
-            <version>0.17.2</version>
-            <configuration>
-              <images>
-                <image>
-                  <name>${project.artifactId}:${project.version}</name>
-                  <alias>test-war-smoke</alias>
-                  <run>
-                    <ports>
-                      <port>${local.app.port}:8080</port>
-                    </ports>
-                  </run>
-                </image>
-              </images>
-            </configuration>
             <executions>
               <execution>
                 <id>start</id>
@@ -122,10 +94,14 @@
     <profile>
       <id>test.remote</id>
       <properties>
+        <!-- change the build timestamp to something palatable for gcloud -->
         <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
         <gcloud-projectId-file>${project.build.directory}/gcloud-projectid.properties
         </gcloud-projectId-file>
-        <!-- remote tests require image in gcr.io -->
+        <!--
+           ~ remote tests require image in gcr.io
+           ~ if local tests are enabled with remote, this image is used locally as well
+           -->
         <jetty.test.image>gcr.io/${app.deploy.project}/jetty:${docker.tag.short}</jetty.test.image>
       </properties>
       <build>
@@ -133,7 +109,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.8</version>
             <executions>
               <execution>
                 <id>find-app-deploy-project</id>
@@ -156,30 +131,11 @@
                   </target>
                 </configuration>
               </execution>
-              <execution>
-                <id>cleanup-integration-test</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>run</goal>
-                </goals>
-                <configuration>
-                  <target>
-                    <exec executable="gcloud">
-                      <arg value="--quiet"/>
-                      <arg value="app"/>
-                      <arg value="versions"/>
-                      <arg value="delete"/>
-                      <arg value="${maven.build.timestamp}"/>
-                    </exec>
-                  </target>
-                </configuration>
-              </execution>
             </executions>
           </plugin>
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>properties-maven-plugin</artifactId>
-            <version>1.0.0</version>
             <executions>
               <execution>
                 <id>read-gcloud-properties</id>
@@ -198,7 +154,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>2.19.1</version>
             <executions>
               <execution>
                 <id>remote-integration-test</id>
@@ -218,6 +173,7 @@
               </execution>
             </executions>
           </plugin>
+          <!-- runs lifecycle to stage and deploy a remote service to test -->
           <plugin>
             <groupId>com.google.cloud.tools</groupId>
             <artifactId>appengine-maven-plugin</artifactId>
@@ -231,6 +187,7 @@
               </execution>
             </executions>
           </plugin>
+          <!-- create tag for local docker image to push for remote use in test -->
           <plugin>
             <groupId>com.spotify</groupId>
             <artifactId>docker-maven-plugin</artifactId>
@@ -251,8 +208,8 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>1.5.0</version>
             <executions>
+              <!-- push a remote docker image to use with 'deploy-integration-test' -->
               <execution>
                 <id>deploy-remote-docker</id>
                 <phase>package</phase>
@@ -266,6 +223,43 @@
                     <argument>-q</argument>
                     <argument>--</argument>
                     <argument>push</argument>
+                    <argument>${jetty.test.image}</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+              <!-- remove the service from 'deploy-integration-test' -->
+              <execution>
+                <id>cleanup-remote-service</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>gcloud</executable>
+                  <arguments>
+                    <argument>--quiet</argument>
+                    <argument>app</argument>
+                    <argument>versions</argument>
+                    <argument>delete</argument>
+                    <argument>${maven.build.timestamp}</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+              <!-- remove the remote image from 'deploy-remote-docker' -->
+              <execution>
+                <id>cleanup-remote-image</id>
+                <phase>post-integration-test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>gcloud</executable>
+                  <arguments>
+                    <argument>docker</argument>
+                    <argument>-q</argument>
+                    <argument>--</argument>
+                    <argument>rmi</argument>
+                    <argument>-f</argument>
                     <argument>${jetty.test.image}</argument>
                   </arguments>
                 </configuration>

--- a/tests/test-war-smoke/pom.xml
+++ b/tests/test-war-smoke/pom.xml
@@ -94,15 +94,13 @@
     <profile>
       <id>test.remote</id>
       <properties>
-        <!-- change the build timestamp to something palatable for gcloud -->
-        <maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
         <gcloud-projectId-file>${project.build.directory}/gcloud-projectid.properties
         </gcloud-projectId-file>
         <!--
            ~ remote tests require image in gcr.io
            ~ if local tests are enabled with remote, this image is used locally as well
            -->
-        <jetty.test.image>gcr.io/${app.deploy.project}/jetty:${docker.tag.short}</jetty.test.image>
+        <jetty.test.image>gcr.io/${app.deploy.project}/jetty:${docker.tag.long}</jetty.test.image>
       </properties>
       <build>
         <plugins>
@@ -139,7 +137,7 @@
                 </goals>
                 <configuration>
                   <target>
-                    <copy file="${project.build.directory}/${project.artifactId}-${project.version}.war"
+                    <copy file="${project.build.directory}/${project.build.finalName}.war"
                           todir="${project.build.directory}/appengine-staging/"/>
                   </target>
                 </configuration>
@@ -211,6 +209,7 @@
                 </configuration>
               </execution>
               <!-- remove the service from 'deploy-integration-test' -->
+              <!--
               <execution>
                 <id>cleanup-remote-service</id>
                 <phase>post-integration-test</phase>
@@ -220,14 +219,15 @@
                 <configuration>
                   <executable>gcloud</executable>
                   <arguments>
-                    <argument>--quiet</argument>
+                    <argument>- -quiet</argument>
                     <argument>app</argument>
                     <argument>versions</argument>
                     <argument>delete</argument>
-                    <argument>${maven.build.timestamp}</argument>
+                    <argument>${maven.build.timestamp}</argument> // this needs to be sha value of image
                   </arguments>
                 </configuration>
               </execution>
+              -->
             </executions>
           </plugin>
         </plugins>
@@ -249,7 +249,7 @@
                   <goal>tag</goal>
                 </goals>
                 <configuration>
-                  <image>jetty:${docker.tag.short}</image>
+                  <image>jetty:${docker.tag.long}</image>
                   <newName>${jetty.test.image}</newName>
                 </configuration>
               </execution>

--- a/tests/test-war-smoke/pom.xml
+++ b/tests/test-war-smoke/pom.xml
@@ -291,7 +291,7 @@
             <executions>
               <execution>
                 <id>tag-image</id>
-                <phase>package</phase>
+                <phase>generate-resources</phase>
                 <goals>
                   <goal>tag</goal>
                 </goals>
@@ -309,7 +309,7 @@
               <!-- push a remote docker image to use with 'deploy-integration-test' -->
               <execution>
                 <id>deploy-remote-docker</id>
-                <phase>package</phase>
+                <phase>generate-resources</phase>
                 <goals>
                   <goal>exec</goal>
                 </goals>


### PR DESCRIPTION
local is default
remote can be activated with -Ptest.remote
both with -Ptest.remote,test.local

figured out part of what is bothersome, the appengine-maven-plugin seems to force a complete new lifecycle so most all the plugins run twice