### PR TITLE
Reuse docker entrypoint from base openjdk image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Google Cloud Platform Jetty Docker Image
 
-This repository contains the source for the `gcr.io/google_appengine/jetty` [docker](https://docker.com) image. This image can be used as the base image for running Java web applications on [Google App Engine Flexible Environment](https://cloud.google.com/appengine/docs/flexible/java/) and [Google Container Engine](https://cloud.google.com/container-engine). It provides the Jetty Servlet container on top of the [OpenJDK image](https://github.com/GoogleCloudPlatform/openjdk-runtime).
+This repository contains the source for the `gcr.io/google-appengine/jetty` [docker](https://docker.com) image. This image can be used as the base image for running Java web applications on [Google App Engine Flexible Environment](https://cloud.google.com/appengine/docs/flexible/java/) and [Google Container Engine](https://cloud.google.com/container-engine). It provides the Jetty Servlet container on top of the [OpenJDK image](https://github.com/GoogleCloudPlatform/openjdk-runtime).
 
 The layout of this image is intended to mostly mimic the official [docker-jetty](https://github.com/appropriate/docker-jetty) image and unless otherwise noted, the official [docker-jetty documentation](https://github.com/docker-library/docs/tree/master/jetty) should apply.
 
@@ -120,10 +120,10 @@ docker run --rm -it jetty:9.4 --list-config --list-modules
 
 ## Extending the image
 
-The image produce by this project may be automatically used/extended by the gcloud SDK and/or gcloud maven plugin. 
+The image produced by this project may be automatically used/extended by the Cloud SDK and/or App Engine maven plugin. 
 Alternately it may be explicitly extended with a custom Dockerfile.  
 
-The latest released verion of this image is available at `gcr.io/google_appengine/jetty`, alternately you may 
+The latest released verion of this image is available at `gcr.io/google-appengine/jetty`, alternately you may 
 build and push your own version with the shell commands:
 ```bash
 mvn clean install
@@ -135,7 +135,7 @@ gcloud docker -- push gcr.io/your-project-name/jetty:your-label
 A standard war file may be deployed as the root context in an extended image by placing the war file 
 in the docker build directory and using a `Dockerfile` like:
 ```dockerfile
-FROM gcr.io/google_appengine/jetty
+FROM gcr.io/google-appengine/jetty
 COPY your-application.war $JETTY_BASE/webapps/root.war
 ```
 
@@ -143,16 +143,16 @@ COPY your-application.war $JETTY_BASE/webapps/root.war
 If the application exists as directory (i.e. an expanded war file), then directory must
 be placed in the docker build directory and using a `Dockerfile` like: 
 ```dockerfile
-FROM gcr.io/google_appengine/jetty
+FROM gcr.io/google-appengine/jetty
 COPY your-application-dir $JETTY_BASE/webapps/root
 ```
 
 ### Mounting the root application at local runtime
 If no root WAR or root directory is found, the `docker-entrypoint.bash` script will link the 
-`/app` directory as the root applicatoin. Thus the root application can be added to the 
+`/app` directory as the root application. Thus the root application can be added to the 
 image via a runtime mount:
 ```bash
-docker run -v /some-path/your-application:/app gcr.io/google_appengine/jetty  
+docker run -v /some-path/your-application:/app gcr.io/google-appengine/jetty  
 ```
 
 # Contributing changes

--- a/jetty9-base/src/main/jetty-base/etc/gae-web.xml
+++ b/jetty9-base/src/main/jetty-base/etc/gae-web.xml
@@ -15,7 +15,7 @@
     </Call>
   </Set>
 
-  <Set name="overrideDescriptor">etc/gae-override-web.xml</Set>
+  <Set name="overrideDescriptor"><Property name="jetty.base"/>/etc/gae-override-web.xml</Set>
   
 </Configure>
 

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -39,8 +39,9 @@ RUN mkdir webapps $TMPDIR \
  && chown -R jetty:jetty $JETTY_BASE $TMPDIR
 
 # Start Jetty directly
-COPY app-env.bash /
-RUN chmod +rx /app-env.bash
+COPY setup-env-ext.bash /tmp/
+RUN cat /tmp/setup-env-ext.bash >> /setup-env.bash \
+ && rm /tmp/setup-env-ext.bash
 
 EXPOSE 8080
 CMD ["java","-Djetty.base=${jetty.base}","-jar","${jetty.home}/start.jar"]

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -39,8 +39,8 @@ RUN mkdir webapps $TMPDIR \
  && chown -R jetty:jetty $JETTY_BASE $TMPDIR
 
 # Start Jetty directly
-COPY docker-entrypoint.bash /
-RUN chmod +rx /docker-entrypoint.bash
+COPY app-env.bash /
+RUN chmod +rx /app-env.bash
 
 EXPOSE 8080
 CMD ["java","-Djetty.base=${jetty.base}","-jar","${jetty.home}/start.jar"]

--- a/jetty9/src/main/docker/app-env.bash
+++ b/jetty9/src/main/docker/app-env.bash
@@ -1,10 +1,7 @@
 #!/bin/bash
 
-# source the supported feature JVM arguments
-source /setup-env.bash
-  
 # default jetty arguments
-export DEFAULT_ARGS="-Djetty.base=$JETTY_BASE -jar $JETTY_HOME/start.jar"
+export JETTY_ARGS="-Djetty.base=$JETTY_BASE -jar $JETTY_HOME/start.jar"
 
 # Unpack a WAR app (if present) beforehand so that Stackdriver Debugger
 # can load it. This should be done before the JVM for Jetty starts up.
@@ -27,16 +24,12 @@ fi
 if [ "java" = "$1" -o "$(which java)" = "$1" ] ; then
   # ignore the java command as it is the default
   shift
-  # clear the default args, use the passed args
-  DEFAULT_ARGS=
+  # clear the JETTY args as the java command has been explicitly set
+  JETTY_ARGS=
 fi
 
 # If the first argument is not executable
 if ! type "$1" &>/dev/null; then
-  # then treat all arguments as arguments to the java command
-  
-  # set the command line to java with the feature arguments and passed arguments
-  set -- java $JAVA_OPTS $DEFAULT_ARGS "$@"
+  # then jetty is being used so add the JETTY_ARGS to the JAVA_OPTS
+  JAVA_OPTS="$JAVA_OPTS $JETTY_ARGS"
 fi
-
-exec "$@"

--- a/jetty9/src/main/docker/setup-env-ext.bash
+++ b/jetty9/src/main/docker/setup-env-ext.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+# The script below is from setup-env-ext.bash, which is appended to /setup-env.bash
 
 # default jetty arguments
 export JETTY_ARGS="-Djetty.base=$JETTY_BASE -jar $JETTY_HOME/start.jar"
@@ -34,3 +34,4 @@ if ! type "$1" &>/dev/null; then
   export JAVA_OPTS="$JAVA_OPTS $JETTY_ARGS"
 fi
 
+# End setup-env-ext.bash

--- a/jetty9/src/main/docker/setup-env-ext.bash
+++ b/jetty9/src/main/docker/setup-env-ext.bash
@@ -31,5 +31,6 @@ fi
 # If the first argument is not executable
 if ! type "$1" &>/dev/null; then
   # then jetty is being used so add the JETTY_ARGS to the JAVA_OPTS
-  JAVA_OPTS="$JAVA_OPTS $JETTY_ARGS"
+  export JAVA_OPTS="$JAVA_OPTS $JETTY_ARGS"
 fi
+

--- a/jetty9/src/test/resources/structure.yaml
+++ b/jetty9/src/test/resources/structure.yaml
@@ -37,6 +37,7 @@ fileExistenceTests:
   path: '/docker-entrypoint.bash'
   isDirectory: false
   shouldExist: true
+  expectedContents: ['.*from setup-env-ext.bash.*End setup-env-ext.bash.*']
 
 licenseTests:
 - debian: true

--- a/jetty9/src/test/resources/structure.yaml
+++ b/jetty9/src/test/resources/structure.yaml
@@ -29,6 +29,10 @@ fileExistenceTests:
   path: '${jetty.base}/webapps'
   isDirectory: true
   shouldExist: true
+- name: 'app-env.bash exists'
+  path: '/app-env.bash'
+  isDirectory: false
+  shouldExist: true
 - name: 'docker entrypoint exists'
   path: '/docker-entrypoint.bash'
   isDirectory: false

--- a/jetty9/src/test/resources/structure.yaml
+++ b/jetty9/src/test/resources/structure.yaml
@@ -29,8 +29,8 @@ fileExistenceTests:
   path: '${jetty.base}/webapps'
   isDirectory: true
   shouldExist: true
-- name: 'app-env.bash exists'
-  path: '/app-env.bash'
+- name: 'setup-env.bash exists'
+  path: '/setup-env.bash'
   isDirectory: false
   shouldExist: true
 - name: 'docker entrypoint exists'

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <docker.tag.prefix></docker.tag.prefix>
     <docker.tag.short>${docker.tag.prefix}9.${jetty9.minor.version}</docker.tag.short>
     <docker.tag.long>${docker.tag.prefix}9.${jetty9.minor.version}-${maven.build.timestamp}</docker.tag.long>
-    <docker.openjdk.image>gcr.io/google_appengine/openjdk:8-2017-01-26_21_19</docker.openjdk.image>
+    <docker.openjdk.image>gcr.io/google-appengine/openjdk:8-2017-01-26_21_19</docker.openjdk.image>
   </properties>
 
   <developers>


### PR DESCRIPTION
Fixes #120 

Move jetty configuration from an overridden docker-entrypoint.bash script
to jetty9/src/main/docker/app-env.bash.

NOT READY for merge, as this depends on https://github.com/GoogleCloudPlatform/openjdk-runtime/pull/49 being available in the base openjdk image.