### PR TITLE
Cloud container builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,19 @@ This repository contains the source for the `gcr.io/google-appengine/jetty` [doc
 The layout of this image is intended to mostly mimic the official [docker-jetty](https://github.com/appropriate/docker-jetty) image and unless otherwise noted, the official [docker-jetty documentation](https://github.com/docker-library/docs/tree/master/jetty) should apply.
 
 ## Building the Jetty image
+### Local build
 To build the image you need git, docker and maven installed:
 ```console
 git clone https://github.com/GoogleCloudPlatform/jetty-runtime.git
 cd jetty-runtime
 mvn clean install
+```
+
+### Cloud build
+To build using the [Google Cloud Container Builder](https://cloud.google.com/container-builder/docs/overview), you need to have git, maven, and the [Google Cloud SDK](https://cloud.google.com/sdk/) installed locally.
+```console
+git clone https://github.com/GoogleCloudPlatform/jetty-runtime.git
+./scripts/cloudbuild.sh
 ```
 
 ## Running the Jetty image

--- a/cloudbuild.yaml.in
+++ b/cloudbuild.yaml.in
@@ -1,0 +1,24 @@
+# Cloud Builder pipeline
+# https://cloud.google.com/container-builder/docs/overview
+
+steps:
+# Perform maven build, omitting local docker operations
+- name: 'maven:3.3.9-jdk-8'
+  args: ['mvn', '-P-local-docker-build', '-P-test.local', 'clean', 'install']
+# Build the runtime container
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=${IMAGE}', '--no-cache', 'jetty9/target/docker']
+
+# Test the built image
+
+# Run our own integration tests
+# TODO this requires the cloud sdk to be installed
+# - name: 'maven:3.3.9-jdk-8'
+#  args: ['mvn', '-P-local-docker-build', '-Ptest.remote', '-Djetty.test.image=${image}', 'verify']
+
+# Runtimes-common structure tests
+# See https://github.com/GoogleCloudPlatform/runtimes-common/tree/master/structure_tests
+- name: 'gcr.io/gcp-runtimes/structure_test'
+  args: ['--image', '${IMAGE}', '-v', '--config', '/workspace/jetty9/target/test-classes/structure.yaml']
+
+images: ['${IMAGE}']

--- a/cloudbuild.yaml.in
+++ b/cloudbuild.yaml.in
@@ -4,7 +4,7 @@
 steps:
 # Perform maven build, omitting local docker operations
 - name: 'maven:3.3.9-jdk-8'
-  args: ['mvn', '-P-local-docker-build', '-P-test.local', 'clean', 'install']
+  args: ['mvn', '-P-local-docker-build', '-P-test.local', '-Ddocker.tag.long=$DOCKER_TAG_LONG', 'clean', 'install']
 # Build the runtime container
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=${IMAGE}', '--no-cache', 'jetty9/target/docker']

--- a/jetty9/pom.xml
+++ b/jetty9/pom.xml
@@ -42,6 +42,80 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <!-- Builds and tests a docker image locally -->
+      <id>local-docker-build</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <imageName>jetty</imageName>
+                  <imageTags>
+                    <imageTag>${docker.tag.short}</imageTag>
+                    <imageTag>${docker.tag.long}</imageTag>
+                  </imageTags>
+                  <dockerDirectory>${project.build.directory}/docker</dockerDirectory>
+                  <pullOnBuild>true</pullOnBuild>
+                </configuration>
+              </execution>
+              <execution>
+                <id>clean-docker</id>
+                <phase>clean</phase>
+                <goals>
+                  <goal>removeImage</goal>
+                </goals>
+                <configuration>
+                  <imageName>jetty</imageName>
+                  <imageTags>
+                    <imageTag>${docker.tag.short}</imageTag>
+                    <imageTag>${docker.tag.long}</imageTag>
+                  </imageTags>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <version>1.5.0</version>
+            <executions>
+              <execution>
+                <id>structure-test</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <executable>../../scripts/structure_test.sh</executable>
+              <workingDirectory>${project.build.directory}</workingDirectory>
+              <arguments>
+                <argument>--image</argument>
+                <argument>jetty:${docker.tag.long}</argument>
+                <argument>--config</argument>
+                <argument>${project.build.testOutputDirectory}/structure.yaml</argument>
+              </arguments>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
   <build>
     <plugins>
       <plugin>
@@ -151,66 +225,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.spotify</groupId>
-        <artifactId>docker-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>build</id>
-            <phase>package</phase>
-            <goals>
-              <goal>build</goal>
-            </goals>
-            <configuration>
-              <imageName>jetty</imageName>
-              <imageTags>
-                <imageTag>${docker.tag.short}</imageTag>
-                <imageTag>${docker.tag.long}</imageTag>
-              </imageTags>
-              <dockerDirectory>${project.build.directory}/docker</dockerDirectory>
-              <pullOnBuild>true</pullOnBuild>
-            </configuration>
-          </execution>
-          <execution>
-            <id>clean-docker</id>
-            <phase>clean</phase>
-            <goals>
-              <goal>removeImage</goal>
-            </goals>
-            <configuration>
-              <imageName>jetty</imageName>
-              <imageTags>
-                <imageTag>${docker.tag.short}</imageTag>
-                <imageTag>${docker.tag.long}</imageTag>
-              </imageTags>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.5.0</version>
-        <executions>
-          <execution>
-            <id>structure-test</id>
-            <phase>integration-test</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>../../scripts/structure_test.sh</executable>
-          <workingDirectory>${project.build.directory}</workingDirectory>
-          <arguments>
-            <argument>--image</argument>
-            <argument>jetty:${docker.tag.long}</argument>
-            <argument>--config</argument>
-            <argument>${project.build.testOutputDirectory}/structure.yaml</argument>
-          </arguments>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -34,7 +34,7 @@ ENV JETTY_BASE ${jetty.base}
 ENV TMPDIR /tmp/jetty
 ADD jetty-base $JETTY_BASE
 WORKDIR $JETTY_BASE
-RUN mkdir webapps $TMPDIR \
+RUN mkdir -p webapps $TMPDIR \
  && java -jar $JETTY_HOME/start.jar --add-to-start=setuid \
  && chown -R jetty:jetty $JETTY_BASE $TMPDIR
 

--- a/jetty9/src/test/resources/structure.yaml
+++ b/jetty9/src/test/resources/structure.yaml
@@ -11,6 +11,9 @@ commandTests:
 - name: 'JETTY_BASE is set'
   command: ['env']
   expectedOutput: ['JETTY_BASE=${jetty.base}']
+- name: 'GAE_IMAGE_LABEL is set'
+  command: ['env']
+  expectedOutput: ['GAE_IMAGE_LABEL=${docker.tag.long}']
 
 fileExistenceTests:
 - name: 'jetty start.jar exists'

--- a/pom.xml
+++ b/pom.xml
@@ -246,13 +246,15 @@
         <artifactId>properties-maven-plugin</artifactId>
         <executions>
           <execution>
+            <!-- Used to output all build properties to be used by other build systems,
+            such as Cloud Container Builder. -->
             <phase>generate-resources</phase>
             <goals>
               <goal>write-project-properties</goal>
             </goals>
             <configuration>
               <outputFile>
-                ${project.build.outputDirectory}/build.properties
+                ${project.build.directory}/build.properties
               </outputFile>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
           <execution>
             <!-- Used to output all build properties to be used by other build systems,
             such as Cloud Container Builder. -->
-            <phase>generate-resources</phase>
+            <id>build-properties</id>
             <goals>
               <goal>write-project-properties</goal>
             </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,23 @@
           </dependency>
         </dependencies>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>write-project-properties</goal>
+            </goals>
+            <configuration>
+              <outputFile>
+                ${project.build.outputDirectory}/build.properties
+              </outputFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/scripts/cloudbuild.sh
+++ b/scripts/cloudbuild.sh
@@ -17,7 +17,7 @@
 set -e
 
 projectRoot=`dirname $0`/..
-buildProperties=$projectRoot/target/classes/build.properties
+buildProperties=$projectRoot/target/build.properties
 
 # reads a property value from a .properties file
 function read_prop {

--- a/scripts/cloudbuild.sh
+++ b/scripts/cloudbuild.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Copyright 2016 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+projectRoot=`dirname $0`/..
+buildProperties=$projectRoot/target/classes/build.properties
+
+# reads a property value from a .properties file
+function read_prop {
+  grep "${1}" $buildProperties | cut -d'=' -f2
+}
+
+# invoke local maven to generate build properties file
+mvn generate-resources
+
+DOCKER_NAMESPACE='gcr.io/$PROJECT_ID'
+RUNTIME_NAME='jetty'
+DOCKER_TAG_LONG=$(read_prop "docker.tag.long")
+
+export IMAGE="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${DOCKER_TAG_LONG}"
+echo "IMAGE: $IMAGE"
+
+mkdir -p $projectRoot/target
+envsubst < $projectRoot/cloudbuild.yaml.in > $projectRoot/target/cloudbuild.yaml
+
+gcloud container builds submit --config=$projectRoot/target/cloudbuild.yaml .
+

--- a/scripts/cloudbuild.sh
+++ b/scripts/cloudbuild.sh
@@ -25,12 +25,11 @@ function read_prop {
 }
 
 # invoke local maven to generate build properties file
-mvn generate-resources
+mvn properties:write-project-properties@build-properties
 
 DOCKER_NAMESPACE='gcr.io/$PROJECT_ID'
 RUNTIME_NAME='jetty'
-DOCKER_TAG_LONG=$(read_prop "docker.tag.long")
-
+export DOCKER_TAG_LONG=$(read_prop "docker.tag.long")
 export IMAGE="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${DOCKER_TAG_LONG}"
 echo "IMAGE: $IMAGE"
 

--- a/tests/test-war-smoke/pom.xml
+++ b/tests/test-war-smoke/pom.xml
@@ -41,39 +41,45 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>com.spotify</groupId>
-        <artifactId>docker-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>build</id>
-            <phase>package</phase>
-            <goals>
-              <goal>build</goal>
-            </goals>
-            <configuration>
-              <imageName>${project.artifactId}</imageName>
-              <imageTags>
-                <imageTag>${project.version}</imageTag>
-              </imageTags>
-              <dockerDirectory>${project.build.directory}/docker</dockerDirectory>
-              <resources>
-                <resource>
-                  <targetPath>/</targetPath>
-                  <directory>${project.build.directory}</directory>
-                  <include>${project.build.finalName}.war</include>
-                </resource>
-              </resources>
-              <forceTags>true</forceTags>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
   <profiles>
+    <profile>
+      <id>local-docker-build</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.spotify</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>build</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>build</goal>
+                </goals>
+                <configuration>
+                  <imageName>${project.artifactId}</imageName>
+                  <imageTags>
+                    <imageTag>${project.version}</imageTag>
+                  </imageTags>
+                  <dockerDirectory>${project.build.directory}/docker</dockerDirectory>
+                  <resources>
+                    <resource>
+                      <targetPath>/</targetPath>
+                      <directory>${project.build.directory}</directory>
+                      <include>${project.build.finalName}.war</include>
+                    </resource>
+                  </resources>
+                  <forceTags>true</forceTags>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>test.local</id>
       <activation>


### PR DESCRIPTION
Adds [Cloud Container Builder](https://cloud.google.com/container-builder/docs/) support. A cloud build can be started by running `scripts/cloudbuild.sh`. 

Note that all local docker-dependent operations have been moved into an active-by-default maven profile named `local-docker-build`, which cloud builds will disable in order to perform an explicit "docker build" as a separate build step. 

Regular maven builds for local development are not impacted by this change.

see also https://github.com/GoogleCloudPlatform/openjdk-runtime/pull/54