### PR TITLE
Fix smoke services delete by adding --no-stop-previous-version to deploy

### DIFF
--- a/tests/test-war-smoke/pom.xml
+++ b/tests/test-war-smoke/pom.xml
@@ -237,12 +237,13 @@
                   <workingDirectory>${project.build.directory}/appengine-staging</workingDirectory>
                   <executable>gcloud</executable>
                   <arguments>
-                    <argument>--quiet</argument>
                     <argument>app</argument>
                     <argument>deploy</argument>
                     <argument>app.yaml</argument>
                     <argument>--version</argument>
                     <argument>${maven.build.timestamp}</argument>
+                    <argument>--no-stop-previous-version</argument>
+                    <argument>--quiet</argument>
                   </arguments>
                 </configuration>
               </execution>

--- a/tests/test-war-smoke/pom.xml
+++ b/tests/test-war-smoke/pom.xml
@@ -261,7 +261,6 @@
                     <argument>services</argument>
                     <argument>delete</argument>
                     <argument>smoke</argument>
-                    <argument>--log-http</argument>
                     <argument>--quiet</argument>
                   </arguments>
                 </configuration>


### PR DESCRIPTION
Applying this workaround for builds failing due to `app services delete` failing.