### PR TITLE
Changes for ci

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -18,14 +18,15 @@ To build using the [Google Cloud Container Builder](https://cloud.google.com/con
 git clone https://github.com/GoogleCloudPlatform/jetty-runtime.git
 cd jetty-runtime
 
-# initiate the cloud build, passing it the docker namespace for the resulting image
+# initiate the cloud build, passing in the docker namespace and tag for the resulting image
 PROJECT_ID=my-project
-./scripts/cloudbuild.sh gcr.io/$PROJECT_ID
+TAG=my-tag
+./scripts/build.sh gcr.io/$PROJECT_ID $TAG
 ```
 
 If you would like to simulate the cloud build locally, pass in the `--local` argument.
 ```
-./scripts/cloudbuild.sh gcr.io/$PROJECT_ID --local
+./scripts/build.sh gcr.io/$PROJECT_ID $TAG --local
 ```
 
 ## Running the Jetty image

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -16,29 +16,21 @@
 
 set -e
 
-dir=`dirname $0`
+dir=$(dirname $0)
 projectRoot=$dir/..
-buildProperties=$projectRoot/target/build.properties
 
 RUNTIME_NAME="jetty"
 DOCKER_NAMESPACE=$1
-if [ -z "${DOCKER_NAMESPACE}" ]; then
-  echo "Usage: ${0} <docker_namespace> [--local]"
+DOCKER_TAG=$2
+
+if [ -z "${DOCKER_NAMESPACE}" -o -z "${DOCKER_TAG}" ]; then
+  echo "Usage: ${0} <docker_namespace> <docker_tag> [--local]"
   exit 1
 fi
-if [ "$2" == "--local" ]; then
+if [ "$3" == "--local" ]; then
   LOCAL_BUILD=true
 fi
 
-# reads a property value from a .properties file
-function read_prop {
-  grep "${1}" $buildProperties | cut -d'=' -f2
-}
-
-# invoke local maven to output build properties file
-mvn clean --non-recursive properties:write-project-properties@build-properties
-
-DOCKER_TAG=$(read_prop "docker.tag.long")
 IMAGE="${DOCKER_NAMESPACE}/${RUNTIME_NAME}:${DOCKER_TAG}"
 echo "IMAGE: $IMAGE"
 

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2016 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build script for CI-like environments, where jobs are configured via environment variables.
+set -e
+
+dir=$(dirname $0)
+
+echo "Invoking build.sh with DOCKER_NAMESPACE=$DOCKER_NAMESPACE, TAG=$TAG"
+source $dir/build.sh $DOCKER_NAMESPACE $TAG
+


### PR DESCRIPTION
Implement a ci-build script to make it easier to build jetty-runtime in a ci-like environment. This is analogous to https://github.com/GoogleCloudPlatform/openjdk-runtime/pull/77.