### PR TITLE
Generate timestamp tag in bash script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -20,13 +20,19 @@ dir=$(dirname $0)
 projectRoot=$dir/..
 
 RUNTIME_NAME="jetty"
+DOCKER_TAG_PREFIX="9.4"
 DOCKER_NAMESPACE=$1
 DOCKER_TAG=$2
 
-if [ -z "${DOCKER_NAMESPACE}" -o -z "${DOCKER_TAG}" ]; then
+if [ -z "${DOCKER_NAMESPACE}" ]; then
   echo "Usage: ${0} <docker_namespace> <docker_tag> [--local]"
   exit 1
 fi
+
+if [ -z "${DOCKER_TAG}" ]; then
+  DOCKER_TAG="${DOCKER_TAG_PREFIX}-$(date +%Y-%m-%d-%H_%M_%S)"
+fi
+
 if [ "$3" == "--local" ]; then
   LOCAL_BUILD=true
 fi


### PR DESCRIPTION
Allows build.sh to be called without specifying the tag. If not specified, we generate it based on the current timestamp.