### PR TITLE
Use openjdk:latest as base image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
   args: ['mvn', '-P-local-docker-build', '-P-test.local', '-Ddocker.tag.long=$_DOCKER_TAG', 'clean', 'install']
 # Build the runtime container
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--tag=${_IMAGE}', '--no-cache', 'jetty9/target/docker']
+  args: ['build', '--tag=${_IMAGE}', '--no-cache', '--pull', 'jetty9/target/docker']
 
 # Test the built image
 

--- a/jetty9/pom.xml
+++ b/jetty9/pom.xml
@@ -69,6 +69,7 @@
                   </imageTags>
                   <dockerDirectory>${project.build.directory}/docker</dockerDirectory>
                   <pullOnBuild>true</pullOnBuild>
+                  <noCache>true</noCache>
                 </configuration>
               </execution>
               <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <docker.tag.prefix></docker.tag.prefix>
     <docker.tag.short>${docker.tag.prefix}9.${jetty9.minor.version}</docker.tag.short>
     <docker.tag.long>${docker.tag.prefix}9.${jetty9.minor.version}-${maven.build.timestamp}</docker.tag.long>
-    <docker.openjdk.image>gcr.io/google-appengine/openjdk:8-2017-03-22_16_09</docker.openjdk.image>
+    <docker.openjdk.image>gcr.io/google-appengine/openjdk</docker.openjdk.image>
   </properties>
 
   <licenses>


### PR DESCRIPTION
Instead of pinning to a specific timestamp release of the openjdk runtime, let's just use openjdk:latest as a base image and force docker to pull on every build. This way we can achieve the same result without requiring a code change whenever the openjdk runtime is updated.

@meltsufin What do you think about this?