### PR TITLE
Add documentation and tests for Gzip compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ RUN java -jar "$JETTY_HOME/start.jar" --add-to-startd=jmx,stats
 ```
 Modules may be configured in a `Dockerfile` by editing the properties in the corresponding mod files in `/var/lib/jetty/start.d/` or the module can be deactivated by removing that file.
 
+### Enabling gzip compression
+The gzip handler is bundled with Jetty but not activated by default. To activate this module you have to set the environment
+variable `JETTY_MODULES_ENABLE=gzip`
+
+For example with docker:
+```console
+docker run -p 8080 -e JETTY_MODULES_ENABLE=gzip gcr.io/yourproject/yourimage
+```
+
+Or with GAE (app.yaml):
+```yaml
+env_variables:
+  JETTY_MODULES_ENABLE: 'gzip'
+```
+
 ## App Engine Flexible Environment
 When using App Engine Flexible, you can use the runtime without worrying about Docker by specifying `runtime: java` in your `app.yaml`:
 ```yaml
@@ -227,21 +242,6 @@ If no root WAR or root directory is found, the `docker-entrypoint.bash` script w
 image via a runtime mount:
 ```bash
 docker run -v /some-path/your-application:/app launcher.gcr.io/google/jetty  
-```
-
-### Enabling gzip compression
-The gzip handler is bundled with Jetty but not activated by default. To activate this module you have to set the environment
-variable `JETTY_MODULES_ENABLE=gzip`
-
-For example with docker:
-```console
-docker run -p 8080 -e JETTY_MODULES_ENABLE=gzip gcr.io/yourproject/yourimage
-```
-
-Or with GAE (app.yaml):
-```yaml
-env_variables:
-  JETTY_MODULES_ENABLE: 'gzip'
 ```
 
 # Development Guide

--- a/README.md
+++ b/README.md
@@ -229,6 +229,21 @@ image via a runtime mount:
 docker run -v /some-path/your-application:/app launcher.gcr.io/google/jetty  
 ```
 
+### Enabling gzip compression
+The gzip handler is bundled with Jetty but not activated by default. To activate this module you have to set the environment
+variable `JETTY_MODULES_ENABLE=gzip`
+
+For example with docker:
+```console
+docker run -p 8080 -e JETTY_MODULES_ENABLE=gzip gcr.io/yourproject/yourimage
+```
+
+Or with GAE (app.yaml):
+```yaml
+env_variables:
+  JETTY_MODULES_ENABLE: 'gzip'
+```
+
 # Development Guide
 
 * See [instructions](DEVELOPING.md) on how to build and test this image.

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -83,6 +83,9 @@
                   <ports>
                     <port>${local.app.port}:8080</port>
                   </ports>
+                  <env>
+                    <JETTY_MODULES_ENABLE>gzip</JETTY_MODULES_ENABLE>
+                  </env>
                 </run>
               </image>
             </images>

--- a/tests/test-war-smoke/src/test/java/com/google/cloud/runtimes/jetty/test/smoke/GzipIntegrationTest.java
+++ b/tests/test-war-smoke/src/test/java/com/google/cloud/runtimes/jetty/test/smoke/GzipIntegrationTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2017 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.runtimes.jetty.test.smoke;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.google.cloud.runtime.jetty.test.AbstractIntegrationTest;
+import com.google.cloud.runtime.jetty.util.HttpUrlUtil;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+
+public class GzipIntegrationTest extends AbstractIntegrationTest {
+
+  /**
+   * Test that the server respond with gzip header when the client allows it.
+   */
+  @Test
+  public void testGzip() throws IOException {
+    URI target = getUri().resolve("/dump/");
+    HttpURLConnection http = HttpUrlUtil.openTo(target);
+    http.setRequestProperty("Accept-Encoding", "gzip");
+    String encoding = http.getHeaderField("Content-Encoding");
+    assertThat(encoding, is("gzip"));
+  }
+
+  /**
+   * Test that the response is not compressed with gzip if the browser does not support it.
+   */
+  @Test
+  public void testUnsupportedGzip() throws IOException {
+    URI target = getUri().resolve("/dump/");
+    HttpURLConnection http = HttpUrlUtil.openTo(target);
+    http.setRequestProperty("Accept-Encoding", "");
+    String encoding = http.getHeaderField("Content-Encoding");
+    assertThat(encoding, is(nullValue()));
+  }
+
+}

--- a/tests/test-war-smoke/src/test/java/com/google/cloud/runtimes/jetty/test/smoke/GzipIntegrationTest.java
+++ b/tests/test-war-smoke/src/test/java/com/google/cloud/runtimes/jetty/test/smoke/GzipIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Google Inc.
+ * Copyright (C) 2016 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR document the usage of gzip compression and add integration tests to check that the headers are correctly set.

Fix #146 