### PR TITLE
Remove travis post-submit build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ jdk:
 
 branches:
   only:
-  - master
   - travis_remote
 
 install:


### PR DESCRIPTION
There's no need for this post-submit build anymore. Let's remove some of the noise from our emails.