### PR TITLE
Add support for Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,14 @@ env_variables:
 ```
 
 ### Using Quickstart
-Jetty provide mechanisms (link to quickstart) to speed up the start time of your application by pre-scanning its content and generating configuration files.
-If you are using an extended image (link to extension) you can activate quickstart by adding this two line to your Dockerfile.
+Jetty provides mechanisms (link to quickstart) to speed up the start time of your application by pre-scanning its content and generating configuration files.
+If you are using an extended image (link to extension) you can activate quickstart by adding this line to your Dockerfile.
 
 ```dockerfile
-ENV GENERATE_QUICKSTART true
-RUN /docker-entrypoint.bash bash
+RUN /docker-entrypoint.bash /scripts/jetty/quickstart.sh
 ```
 
-This commands must appear after the command to add the war file.
+This command must appears after the command to add the war file.
 ## App Engine Flexible Environment
 When using App Engine Flexible, you can use the runtime without worrying about Docker by specifying `runtime: java` in your `app.yaml`:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Jetty provides [mechanisms](http://www.eclipse.org/jetty/documentation/9.4.x/qui
 If you are using an [extended image](https://github.com/GoogleCloudPlatform/jetty-runtime/blob/master/README.md#extending-the-image) you can activate quickstart by adding this command to your Dockerfile.
 
 ```dockerfile
-RUN /docker-entrypoint.bash /scripts/jetty/quickstart.sh
+RUN /scripts/jetty/quickstart.sh
 ```
 
 This command must appears after the command to add your war file.

--- a/README.md
+++ b/README.md
@@ -57,14 +57,15 @@ env_variables:
 ```
 
 ### Using Quickstart
-Jetty provides mechanisms (link to quickstart) to speed up the start time of your application by pre-scanning its content and generating configuration files.
-If you are using an extended image (link to extension) you can activate quickstart by adding this line to your Dockerfile.
+Jetty provides [mechanisms](http://www.eclipse.org/jetty/documentation/9.4.x/quickstart-webapp.html) to speed up the start time of your application by pre-scanning its content and generating configuration files.
+If you are using an [extended image](https://github.com/GoogleCloudPlatform/jetty-runtime/blob/master/README.md#extending-the-image) you can activate quickstart by adding this command to your Dockerfile.
 
 ```dockerfile
 RUN /docker-entrypoint.bash /scripts/jetty/quickstart.sh
 ```
 
-This command must appears after the command to add the war file.
+This command must appears after the command to add your war file.
+
 ## App Engine Flexible Environment
 When using App Engine Flexible, you can use the runtime without worrying about Docker by specifying `runtime: java` in your `app.yaml`:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -58,13 +58,15 @@ env_variables:
 
 ### Using Quickstart
 Jetty provides [mechanisms](http://www.eclipse.org/jetty/documentation/9.4.x/quickstart-webapp.html) to speed up the start time of your application by pre-scanning its content and generating configuration files.
-If you are using an [extended image](https://github.com/GoogleCloudPlatform/jetty-runtime/blob/master/README.md#extending-the-image) you can activate quickstart by adding this command to your Dockerfile.
+If you are using an [extended image](https://github.com/GoogleCloudPlatform/jetty-runtime/blob/master/README.md#extending-the-image) you can active quickstart by executing `/scripts/jetty/quickstart.sh` in your Dockerfile, after the application WAR is added.
 
 ```dockerfile
+FROM launcher.gcr.io/google/jetty
+ADD your-application.war $JETTY_BASE/webapps/root.war
+
+# generate quickstart-web.xml
 RUN /scripts/jetty/quickstart.sh
 ```
-
-This command must appears after the command to add your war file.
 
 ## App Engine Flexible Environment
 When using App Engine Flexible, you can use the runtime without worrying about Docker by specifying `runtime: java` in your `app.yaml`:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ env_variables:
   JETTY_MODULES_ENABLE: 'gzip'
 ```
 
+### Using Quickstart
+Jetty provide mechanisms (link to quickstart) to speed up the start time of your application by pre-scanning its content and generating configuration files.
+If you are using an extended image (link to extension) you can activate quickstart by adding this two line to your Dockerfile.
+
+```dockerfile
+ENV GENERATE_QUICKSTART true
+RUN /docker-entrypoint.bash bash
+```
+
+This commands must appear after the command to add the war file.
 ## App Engine Flexible Environment
 When using App Engine Flexible, you can use the runtime without worrying about Docker by specifying `runtime: java` in your `app.yaml`:
 ```yaml

--- a/jetty9/src/main/docker/50-jetty.bash
+++ b/jetty9/src/main/docker/50-jetty.bash
@@ -46,16 +46,6 @@ if [ "$JETTY_MODULES_DISABLE" ]; then
   done
 fi
 
-# Generate configuration files for quickstart
-if [ "$GENERATE_QUICKSTART" = "true" ] && [ ! -e "$JETTY_BASE/webapps/root/WEB-INF/quickstart-web.xml" ]; then
-  pushd $JETTY_BASE
-  java -jar $JETTY_HOME/start.jar --add-to-start=quickstart
-  QUICKSTART_CLASSPATH=$(java -jar $JETTY_HOME/start.jar --dry-run)
-  # Replace the Xml configuration class with the Quickstart pre configuration class
-  $( echo "$QUICKSTART_CLASSPATH" | sed 's/org.eclipse.jetty.xml.XmlConfiguration.*/org.eclipse.jetty.quickstart.PreconfigureQuickStartWar webapps\/root.war/')
-  popd
-fi
-
 # If we are deployed on a GAE platform, enable the gcp module
 if [ "$PLATFORM" = "gae" ]; then
   JETTY_ARGS="$JETTY_ARGS --module=gcp"

--- a/jetty9/src/main/docker/50-jetty.bash
+++ b/jetty9/src/main/docker/50-jetty.bash
@@ -46,6 +46,16 @@ if [ "$JETTY_MODULES_DISABLE" ]; then
   done
 fi
 
+# Generate configuration files for quickstart
+if [ "$GENERATE_QUICKSTART" = "true" ] && [ ! -e "$JETTY_BASE/webapps/root/WEB-INF/quickstart-web.xml" ]; then
+  pushd $JETTY_BASE
+  java -jar $JETTY_HOME/start.jar --add-to-start=quickstart
+  QUICKSTART_CLASSPATH=$(java -jar $JETTY_HOME/start.jar --dry-run)
+  # Replace the Xml configuration class with the Quickstart pre configuration class
+  $( echo "$QUICKSTART_CLASSPATH" | sed 's/org.eclipse.jetty.xml.XmlConfiguration.*/org.eclipse.jetty.quickstart.PreconfigureQuickStartWar webapps\/root.war/')
+  popd
+fi
+
 # If we are deployed on a GAE platform, enable the gcp module
 if [ "$PLATFORM" = "gae" ]; then
   JETTY_ARGS="$JETTY_ARGS --module=gcp"

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -34,11 +34,13 @@ ENV JETTY_BASE ${jetty.base}
 ENV TMPDIR /tmp/jetty
 ADD jetty-base $JETTY_BASE
 ADD 50-jetty.bash /setup-env.d/
+ADD quickstart.sh /scripts/jetty/quickstart.sh
 WORKDIR $JETTY_BASE
 RUN mkdir -p webapps $TMPDIR \
  && java -jar $JETTY_HOME/start.jar --add-to-start=setuid \
  && chown -R jetty:jetty $JETTY_BASE $TMPDIR \
- && chmod +x /setup-env.d/50-jetty.bash
+ && chmod +x /setup-env.d/50-jetty.bash \
+ && chmod +x /scripts/jetty/quickstart.sh
 
 EXPOSE 8080
 CMD ["java","-Djetty.base=${jetty.base}","-jar","${jetty.home}/start.jar"]

--- a/jetty9/src/main/docker/quickstart.sh
+++ b/jetty9/src/main/docker/quickstart.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Enable quickstart module for Jetty and eagerly generate the quickstart-web.xml
 
-# Generate configuration files for quickstart [ "$GENERATE_QUICKSTART" = "true" ] &&
+# Generate configuration files for quickstart
 if [ ! -e "$JETTY_BASE/webapps/root/WEB-INF/quickstart-web.xml" ]; then
   pushd ${JETTY_BASE}
   java -jar ${JETTY_HOME}/start.jar --add-to-start=quickstart

--- a/jetty9/src/main/docker/quickstart.sh
+++ b/jetty9/src/main/docker/quickstart.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Enable quickstart module for Jetty and eagerly generate the quickstart-web.xml
+
+# Generate configuration files for quickstart [ "$GENERATE_QUICKSTART" = "true" ] &&
+if [ ! -e "$JETTY_BASE/webapps/root/WEB-INF/quickstart-web.xml" ]; then
+  pushd ${JETTY_BASE}
+  java -jar ${JETTY_HOME}/start.jar --add-to-start=quickstart
+  QUICKSTART_CLASSPATH=$(java -jar ${JETTY_HOME}/start.jar --dry-run)
+  # Replace the Xml configuration class with the Quickstart pre configuration class
+  $( echo "$QUICKSTART_CLASSPATH" | sed 's/org.eclipse.jetty.xml.XmlConfiguration.*/org.eclipse.jetty.quickstart.PreconfigureQuickStartWar webapps\/root.war/')
+  popd
+fi

--- a/jetty9/src/main/docker/quickstart.sh
+++ b/jetty9/src/main/docker/quickstart.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Enable quickstart module for Jetty and eagerly generate the quickstart-web.xml
 
+source /docker-entrypoint.bash bash
+
 # Generate configuration files for quickstart
 if [ ! -e "$JETTY_BASE/webapps/root/WEB-INF/quickstart-web.xml" ]; then
   pushd ${JETTY_BASE}

--- a/jetty9/src/main/docker/quickstart.sh
+++ b/jetty9/src/main/docker/quickstart.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 # Enable quickstart module for Jetty and eagerly generate the quickstart-web.xml
 
-source /docker-entrypoint.bash bash
-
 # Generate configuration files for quickstart
 if [ ! -e "$JETTY_BASE/webapps/root/WEB-INF/quickstart-web.xml" ]; then
   pushd ${JETTY_BASE}
   java -jar ${JETTY_HOME}/start.jar --add-to-start=quickstart
-  QUICKSTART_CLASSPATH=$(java -jar ${JETTY_HOME}/start.jar --dry-run)
-  # Replace the Xml configuration class with the Quickstart pre configuration class
-  $( echo "$QUICKSTART_CLASSPATH" | sed 's/org.eclipse.jetty.xml.XmlConfiguration.*/org.eclipse.jetty.quickstart.PreconfigureQuickStartWar webapps\/root.war/')
+  JETTY_START_COMMAND=$(java -jar ${JETTY_HOME}/start.jar --dry-run)
+   # Replace the Xml configuration class with the Quickstart pre configuration class
+  QUICKSTART_START_COMMAND=$(echo ${JETTY_START_COMMAND} | sed 's/org.eclipse.jetty.xml.XmlConfiguration.*/org.eclipse.jetty.quickstart.PreconfigureQuickStartWar/')
+  /docker-entrypoint.bash ${QUICKSTART_START_COMMAND} "$ROOT_WAR"
   popd
 fi

--- a/jetty9/src/test/resources/structure.yaml
+++ b/jetty9/src/test/resources/structure.yaml
@@ -66,6 +66,10 @@ fileExistenceTests:
   isDirectory: false
   shouldExist: true
   expectedContents: ['.*from setup-env-ext.bash.*End setup-env-ext.bash.*']
+- name: 'jetty quickstart exists'
+  path: '/scripts/jetty/quickstart.sh'
+  isDirectory: false
+  shouldExist: true
 
 licenseTests:
 - debian: true


### PR DESCRIPTION
This PR allows users extending the Jetty runtime image to use Jetty quickstart and to eagerly generate quickstart-web.xml.

Currently only the existence of the quickstart script is tested but there is a possibility to create a new test application for quickstart if needed.

Fix #12 
