### PR TITLE
Add structure test for debugger jvm args

### DIFF
--- a/jetty9/src/test/resources/structure.yaml
+++ b/jetty9/src/test/resources/structure.yaml
@@ -39,6 +39,11 @@ commandTests:
   command: [ '/workspace/jetty9/src/test/workspace/jetty-setup-modules.bash' ]
   expectedOutput: ['OK']
   exitCode: 0
+- name: 'cloud debugger extra class path is set'
+  setup: [[ 'chmod', '+x', '/workspace/jetty9/src/test/workspace/jetty-setup-debugger.bash' ]]
+  command: ['/workspace/jetty9/src/test/workspace/jetty-setup-debugger.bash']
+  expectedOutput: ['OK']
+  exitCode: 0
 
 fileExistenceTests:
 - name: 'jetty start.jar exists'

--- a/jetty9/src/test/workspace/jetty-setup-debugger.bash
+++ b/jetty9/src/test/workspace/jetty-setup-debugger.bash
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+EXPECTED_DBG_AGENT='-agentpath:/opt/cdbg/cdbg_java_agent.so=--log_dir=/var/log/app_engine,--alsologtostderr=true,--cdbg_extra_class_path=/var/lib/jetty/webapps/root/WEB-INF/classes:/var/lib/jetty/webapps/root/WEB-INF/lib'
+ACTUAL_DBG_AGENT="$(export GAE_INSTANCE=instance; /docker-entrypoint.bash env | grep DBG_AGENT | cut -d '=' -f 1 --complement)"
+
+if [ $ACTUAL_DBG_AGENT != "$EXPECTED_DBG_AGENT" ]; then
+  echo "DBG_AGENT='$(echo ${ACTUAL_DBG_AGENT})'"
+  exit 1
+else
+  echo OK
+fi


### PR DESCRIPTION
This PR adds a test that ensures the cloud debugger agent is properly set up. This will fail until https://github.com/GoogleCloudPlatform/jetty-runtime/pull/175 is merged in.