### PR TITLE
Fix Cloud Debugger [WIP]

### DIFF
--- a/jetty9-base/src/main/jetty-base/config-scripts/jetty.commands
+++ b/jetty9-base/src/main/jetty-base/config-scripts/jetty.commands
@@ -1,4 +1,3 @@
 --create-startd
---approve-all-licenses
---add-to-start=server,webapp,http,deploy,jsp,jstl,resources,logging-jul,jcl-slf4j
+--add-to-start=server,webapp,http,deploy,jsp,jstl,resources
 


### PR DESCRIPTION
I'm not sure why, but reverting the `jetty.comands` file to the way it was before logging PR was merged in, fixes the Cloud Debugger functionality.

Fixes issue #174 

@gregw Any clues?