### PR TITLE
Run jetty smoke tests as part of ci-build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,11 +11,6 @@ steps:
 
 # Test the built image
 
-# Run our own integration tests
-# TODO this requires the cloud sdk to be installed
-# - name: 'maven:3.3.9-jdk-8'
-#  args: ['mvn', '-P-local-docker-build', '-Ptest.remote', '-Djetty.test.image=${image}', 'verify']
-
 # Runtimes-common structure tests
 # See https://github.com/GoogleCloudPlatform/runtimes-common/tree/master/structure_tests
 - name: 'gcr.io/gcp-runtimes/structure_test'

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -32,3 +32,9 @@ echo "Invoking build.sh with DOCKER_NAMESPACE=$DOCKER_NAMESPACE, TAG=$TAG"
 IMAGE=$DOCKER_NAMESPACE/jetty:$TAG
 echo "Running integration tests on image: $IMAGE"
 ./scripts/integration_test.sh $IMAGE
+
+echo "Running jetty smoke tests on image: $IMAGE"
+pushd tests/
+mvn install -Djetty.test.image=$IMAGE -Ptest.remote,test.local
+popd
+


### PR DESCRIPTION
Runs the jetty smoke tests as part of our continuous (post-submit) builds. Once we are able to grant GAE deploy permission to Container Builder's service account, we should run these tests from within Container Builder.