### PR TITLE
Skip local tests when running a remote build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@
 steps:
 # Perform maven build, omitting local docker operations
 - name: 'maven:3.3.9-jdk-8'
-  args: ['mvn', '-P-local-docker-build', '-P-test.local', '-Ddocker.tag.long=$_DOCKER_TAG', 'clean', 'install']
+  args: ['mvn', '-B', '-P-local-docker-build', '-P-test.local', '-Ddocker.tag.long=$_DOCKER_TAG', 'clean', 'install']
 # Build the runtime container
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '--tag=${_IMAGE}', '--no-cache', 'jetty9/target/docker']

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -35,6 +35,6 @@ echo "Running integration tests on image: $IMAGE"
 
 echo "Running jetty smoke tests on image: $IMAGE"
 pushd tests/
-mvn install -Djetty.test.image=$IMAGE -Ptest.remote,test.local
+mvn -B install -Djetty.test.image=$IMAGE -Ptest.remote
 popd
 


### PR DESCRIPTION
Running local tests requires that a container with the smoke test application is available locally. Since we run our docker builds on Container Builder, the image isn't able to be found by the maven process running within the `ci-build` script.

Also, run maven in batch mode to clean up our logs.