### PR TITLE
Application default credentials

### DIFF
--- a/scripts/gcloud-init.sh
+++ b/scripts/gcloud-init.sh
@@ -44,4 +44,6 @@ export PATH=$DIR/google-cloud-sdk/bin:$PATH
 
 gcloud auth activate-service-account --key-file=$KEYFILE
 gcloud config set project $GCP_PROJECT
+export GOOGLE_APPLICATION_CREDENTIALS=$KEYFILE
+
 gcloud components install beta -q

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -31,7 +31,7 @@ fi
 
 # build the test app
 pushd $testAppDir
-mvn clean install
+mvn -B clean install
 popd
 
 # deploy to app engine


### PR DESCRIPTION
The jetty smoke tests make use of [Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials) to authenticate with certain GCP APIs. In certain versions of the Cloud SDK, application default creds are not set up by default, so we need to explicitly configure them.