### PR TITLE
Configure JUL via JETTY_ARGS, because jetty itself needs this property

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,10 +123,10 @@ Additional environment variables are used/set including:
 |`JETTY_PROPERTIES`|                 |Comma separated list of `name=value` pairs appended to `$JETTY_ARGS` |
 |`JETTY_MODULES_ENABLE`|            |Comma separated list of modules to enable by appending to `$JETTY_ARGS` |
 |`JETTY_MODULES_DISABLE`|           |Comma separated list of modules to disable by removing from `$JETTY_BASE/start.d` |
-|`JETTY_ARGS`      |                 |`-Djetty.base=$JETTY_BASE -jar $JETTY_HOME/start.jar` |
+|`JETTY_ARGS`      |                 |Arguments passed to jetty's `start.jar`. Any arguments used for custom jetty configuration should be passed here. |
 |`ROOT_WAR`        |                 |`$JETTY_BASE/webapps/root.war`                        |
 |`ROOT_DIR`        |                 |`$JETTY_BASE/webapps/root`                            |
-|`JAVA_OPTS`       |                 |`$JAVA_OPTS $JETTY_ARGS`                              |
+|`JAVA_OPTS`       |                 |JVM runtime arguments                                 |
 
 If a WAR file is found at `$ROOT_WAR`, it is unpacked to `$ROOT_DIR` if it is newer than the directory or the directory
 does not exist.  If there is no `$ROOT_WAR` or `$ROOT_DIR`, then `/app` is symbolic linked to `$ROOT_DIR`. If 

--- a/README.md
+++ b/README.md
@@ -157,14 +157,14 @@ and the Java System Property `java.util.logging.config.file` updated to referenc
 When running in a GCP environment, the system property can be set in `app.yaml`:
 ```yaml
 env_variables:
-  JAVA_USER_OPTS: -Djava.util.logging.config.file=WEB-INF/logging.properties
+  JETTY_ARGS: -Djava.util.logging.config.file=WEB-INF/logging.properties
 ```
 
 If the image is run directly, then a `-e` argument to the `docker run` command can be used to set the system property:
 
 ```bash
 docker run \
-  -e JAVA_USER_OPTS=-Djava.util.logging.config.file=WEB-INF/logging.properties \
+  -e JETTY_ARGS=-Djava.util.logging.config.file=WEB-INF/logging.properties \
   ...
 ```
 
@@ -184,7 +184,7 @@ Alternately an entirely new location for the file can be provided and the enviro
 ```Dockerfile
 FROM gcr.io/google-appengine/jetty
 ADD logging.properties /etc/logging.properties
-ENV JAVA_USER_OPTS -Djava.util.logging.config.file=/etc/logging.properties
+ENV JETTY_ARGS -Djava.util.logging.config.file=/etc/logging.properties
 ...
 ```
 
@@ -193,7 +193,7 @@ A `logging.properties` file may be added to an existing images using the `docker
 ```shell 
 docker run -it --rm \
 -v /mylocaldir/logging.properties:/etc/logging.properties \
--e JAVA_USER_OPTS="-Djava.util.logging.config.file=/etc/logging.properties" \
+-e JETTY_ARGS="-Djava.util.logging.config.file=/etc/logging.properties" \
 ...
 ```
 

--- a/tests/test-war-smoke/src/main/appengine/app.yaml
+++ b/tests/test-war-smoke/src/main/appengine/app.yaml
@@ -14,5 +14,5 @@ handlers:
   secure: optional
 
 env_variables:
-  JAVA_USER_OPTS: -Djava.util.logging.config.file=WEB-INF/logging.properties
+  JETTY_ARGS: -Djava.util.logging.config.file=WEB-INF/logging.properties
   JETTY_MODULES_ENABLE: gzip


### PR DESCRIPTION
This PR changes the way we document java-util-logging configuration. Now, it should be configured using JETTY_ARGS, instead of JAVA_USER_OPTS.   

**Why?**
* The java system property `-Djava.util.logging.config.file` needs to be read by jetty's start.jar in order to generate the properly configured start command. If it's not present when start.jar runs, it will generate a java start command with jetty's default JUL config file. 
* JETTY_ARGS is currently passed to start.jar the sensible place for java properties that start.jar needs. (See also `-Djettty.base`)

**More background**
The changes in https://github.com/GoogleCloudPlatform/jetty-runtime/pull/183 have changed the way the jetty start command is generated - with those changes, the command is generated in a jetty dry-run, then executed separately. After the command is generated, we manually inject the computed $JAVA_OPTS into the start command before executing it. Since JAVA_OPTS contains JAVA_USER opts, any JUL configuration overrides aren't currently available to jetty at start-command-generation-time.
