### PR TITLE
Revert scripts

### DIFF
--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -25,16 +25,5 @@ source $dir/gcloud-init.sh
 
 cd github/jetty-runtime
 export TAG=$(git rev-parse --short HEAD)
-
-echo "Invoking build.sh with DOCKER_NAMESPACE=$DOCKER_NAMESPACE, TAG=$TAG"
-./scripts/build.sh $DOCKER_NAMESPACE $TAG
-
-IMAGE=$DOCKER_NAMESPACE/jetty:$TAG
-echo "Running integration tests on image: $IMAGE"
-./scripts/integration_test.sh $IMAGE
-
-echo "Running jetty smoke tests on image: $IMAGE"
-pushd tests/
-mvn -B install -Djetty.test.image=$IMAGE -Ptest.remote
-popd
+./scripts/build.sh --docker-namespace $DOCKER_NAMESPACE --tag $TAG
 

--- a/scripts/ci-build.sh
+++ b/scripts/ci-build.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Copyright 2016 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build script for CI-like environments. Sets up local dependencies required for performing a
+# continuous-integration build.
+set -e
+
+dir=$(dirname $0)
+
+# downloads, unpacks, installs the cloud SDK
+source $dir/gcloud-init.sh
+
+cd github/jetty-runtime
+export TAG=$(git rev-parse --short HEAD)
+
+echo "Invoking build.sh with DOCKER_NAMESPACE=$DOCKER_NAMESPACE, TAG=$TAG"
+./scripts/build.sh $DOCKER_NAMESPACE $TAG
+
+IMAGE=$DOCKER_NAMESPACE/jetty:$TAG
+echo "Running integration tests on image: $IMAGE"
+./scripts/integration_test.sh $IMAGE
+
+echo "Running jetty smoke tests on image: $IMAGE"
+pushd tests/
+mvn -B install -Djetty.test.image=$IMAGE -Ptest.remote
+popd
+

--- a/scripts/gcloud-init.sh
+++ b/scripts/gcloud-init.sh
@@ -20,18 +20,8 @@ set -ex
 
 DIR=$(pwd)
 
-if [ -z $GCLOUD_FILE ]; then
-  echo '$GCLOUD_FILE environment variable must be set.'
-  exit 1
-fi
-
-if [ -z $KEYFILE ]; then
-  echo '$KEYFILE environment variable must be set.'
-  exit 1
-fi
-
-if [ -z $GCP_PROJECT ]; then
-  echo '$GCP_PROJECT environment variable must be set.'
+if [ -z $GCLOUD_FILE -o -z $KEYFILE -o -z $GCP_PROJECT ]; then
+  echo '$GCLOUD_FILE, $KEYFILE, and $GCP_PROJECT environment variables must be set.'
   exit 1
 fi
 

--- a/scripts/gcloud-init.sh
+++ b/scripts/gcloud-init.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright 2016 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Set up gcloud and auth
+set -ex
+
+DIR=$(pwd)
+
+if [ -z $GCLOUD_FILE ]; then
+  echo '$GCLOUD_FILE environment variable must be set.'
+  exit 1
+fi
+
+if [ -z $KEYFILE ]; then
+  echo '$KEYFILE environment variable must be set.'
+  exit 1
+fi
+
+if [ -z $GCP_PROJECT ]; then
+  echo '$GCP_PROJECT environment variable must be set.'
+  exit 1
+fi
+
+LOCAL_GCLOUD_FILE=gcloud.tar.gz
+cp $GCLOUD_FILE $LOCAL_GCLOUD_FILE
+
+# Hide the output here, it's long.
+tar -xzf $LOCAL_GCLOUD_FILE
+export PATH=$DIR/google-cloud-sdk/bin:$PATH
+
+gcloud auth activate-service-account --key-file=$KEYFILE
+gcloud config set project $GCP_PROJECT
+export GOOGLE_APPLICATION_CREDENTIALS=$KEYFILE
+
+gcloud components install beta -q


### PR DESCRIPTION
Restores some of the build scripts that were deleted with https://github.com/GoogleCloudPlatform/jetty-runtime/pull/189. Internal CI requires that these scripts reside among the sources being built.