### PR TITLE
Use BASH_SOURCE to find location of a sourced script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -45,7 +45,7 @@ while [[ $# -gt 1 ]]; do
   shift
 done
 
-dir=$(dirname $0)
+dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 projectRoot=${dir}/..
 buildConfigDir=${projectRoot}/build/config
 


### PR DESCRIPTION
The build script is being sourced by other scripts during release. This change allows the script to properly find its location in those cases.

See https://stackoverflow.com/a/246128/5053647 for more detail.