### PR TITLE
Bump jetty base openjdk image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <docker.tag.prefix></docker.tag.prefix>
     <docker.tag.short>${docker.tag.prefix}9.${jetty9.minor.version}</docker.tag.short>
     <docker.tag.long>${docker.tag.prefix}9.${jetty9.minor.version}-${maven.build.timestamp}</docker.tag.long>
-    <docker.openjdk.image>gcr.io/google-appengine/openjdk:8-2017-06-05_18_21</docker.openjdk.image>
+    <docker.openjdk.image>gcr.io/google-appengine/openjdk:8-2017-06-15_19_28</docker.openjdk.image>
   </properties>
 
   <licenses>


### PR DESCRIPTION
Use new base image that contains security fixes.