### PR TITLE
Add local container tests for shutdown logging

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -6,7 +6,7 @@ This document contains instructions on how to build and test this image.
 
 ### Local build
 To build the image you need git, docker and maven installed:
-```console
+```bash
 git clone https://github.com/GoogleCloudPlatform/jetty-runtime.git
 cd jetty-runtime
 mvn clean install
@@ -14,15 +14,16 @@ mvn clean install
 
 ### Cloud build
 To build using the [Google Cloud Container Builder](https://cloud.google.com/container-builder/docs/overview), you need to have git, maven, and the [Google Cloud SDK](https://cloud.google.com/sdk/) installed locally.
-```console
+```bash
 git clone https://github.com/GoogleCloudPlatform/jetty-runtime.git
 cd jetty-runtime
 
 # initiate the cloud build, passing in the docker namespace and tag for the resulting image
 PROJECT_ID=my-project
-TAG=my-tag
-./scripts/build.sh gcr.io/$PROJECT_ID $TAG
+TAG=my-tag                        # optional
+./scripts/build.sh -d gcr.io/$PROJECT_ID -t $TAG
 ```
+
 The configured Cloud Build execution will build the Jetty docker container, then create and teardown various GCP resources for 
 integration testing. Before running, make sure you have done the following:
  * enabled the Cloud Container Builder API
@@ -32,7 +33,7 @@ integration testing. Before running, make sure you have done the following:
 ## Running the Jetty image
 The resulting image is called jetty (with more specific tags also created)
 and can be run with:
-```console
+```bash
 docker run jetty
 ```
 

--- a/build/config/build.yaml
+++ b/build/config/build.yaml
@@ -82,12 +82,4 @@ steps:
   dir: 'tests/'
   waitFor: ['DOCKER_STAGE', 'DOCKER_BUILD_MVN_GCLOUD']
 
-# Local docker integration tests
-- name: 'mvn-gcloud'
-  id: 'LOCAL_DOCKER_INTEGRATION_TEST'
-  entrypoint: 'scripts/local_integration_test.sh'
-  args:
-    - '${_STAGING_IMAGE}'
-  waitFor: ['DOCKER_STAGE', 'DOCKER_BUILD_MVN_GCLOUD']
-
 images: ['${_IMAGE}']

--- a/build/config/build.yaml
+++ b/build/config/build.yaml
@@ -82,4 +82,12 @@ steps:
   dir: 'tests/'
   waitFor: ['DOCKER_STAGE', 'DOCKER_BUILD_MVN_GCLOUD']
 
+# Local docker integration tests
+- name: 'mvn-gcloud'
+  id: 'LOCAL_DOCKER_INTEGRATION_TEST'
+  entrypoint: 'scripts/local_integration_test.sh'
+  args:
+    - '${_STAGING_IMAGE}'
+  waitFor: ['DOCKER_STAGE', 'DOCKER_BUILD_MVN_GCLOUD']
+
 images: ['${_IMAGE}']

--- a/jetty9/pom.xml
+++ b/jetty9/pom.xml
@@ -98,20 +98,34 @@
                 <goals>
                   <goal>exec</goal>
                 </goals>
+                <configuration>
+                  <executable>../../scripts/structure_test.sh</executable>
+                  <workingDirectory>${project.build.directory}</workingDirectory>
+                  <arguments>
+                    <argument>--image</argument>
+                    <argument>jetty:${docker.tag.long}</argument>
+                    <argument>--workspace</argument>
+                    <argument>${project.basedir}/..</argument>
+                    <argument>--config</argument>
+                    <argument>${project.build.testOutputDirectory}/structure.yaml</argument>
+                  </arguments>
+                </configuration>
+              </execution>
+              <execution>
+                <id>integration-test</id>
+                <phase>integration-test</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+                <configuration>
+                  <executable>../../scripts/local_integration_test.sh</executable>
+                  <workingDirectory>${project.build.directory}</workingDirectory>
+                  <arguments>
+                    <argument>jetty:${docker.tag.long}</argument>
+                  </arguments>
+                </configuration>
               </execution>
             </executions>
-            <configuration>
-              <executable>../../scripts/structure_test.sh</executable>
-              <workingDirectory>${project.build.directory}</workingDirectory>
-              <arguments>
-                <argument>--image</argument>
-                <argument>jetty:${docker.tag.long}</argument>
-                <argument>--workspace</argument>
-                <argument>${project.basedir}/..</argument>
-                <argument>--config</argument>
-                <argument>${project.build.testOutputDirectory}/structure.yaml</argument>
-              </arguments>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/scripts/local_integration_test.sh
+++ b/scripts/local_integration_test.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Copyright 2017 Google Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# exit on command failure
+set -e
+
+readonly dir=$(dirname $0)
+readonly projectRoot="$dir/.."
+readonly testAppDir="$projectRoot/tests/test-war-smoke"
+readonly deployDir="$testAppDir/target/docker"
+
+APP_IMAGE='jetty-local-integration'
+CONTAINER=${APP_IMAGE}-container
+OUTPUT_FILE=${CONTAINER}-output.txt
+
+readonly imageUnderTest=$1
+if [[ -z "$imageUnderTest" ]]; then
+  echo "Usage: ${0} <image_under_test>"
+  exit 1
+fi
+
+# build the test app
+pushd ${testAppDir}
+mvn clean install -Djetty.test.image=$imageUnderTest
+popd
+
+# build app container locally
+pushd $deployDir
+echo "Building app container..."
+docker build -t $APP_IMAGE .
+
+# run app container locally to test shutdown logging
+echo "Starting app container..."
+docker run --rm --name $CONTAINER -e "SHUTDOWN_LOGGING_THREAD_DUMP=true" -e "SHUTDOWN_LOGGING_HEAP_INFO=true" $APP_IMAGE &> $OUTPUT_FILE &
+
+timeout 10 grep -q 'Server: Started' <(tail -f $OUTPUT_FILE 2> /dev/null)
+
+docker stop $CONTAINER
+
+docker rmi $APP_IMAGE
+
+echo 'verify thread dump'
+grep 'Full thread dump OpenJDK 64-Bit Server VM' $OUTPUT_FILE &> /dev/null
+
+echo 'verify heap info'
+grep 'num.*instances.*bytes.*class name' $OUTPUT_FILE &> /dev/null
+
+popd
+
+echo 'OK'

--- a/scripts/local_integration_test.sh
+++ b/scripts/local_integration_test.sh
@@ -36,7 +36,7 @@ fi
 # build the test app
 pushd ${testAppDir}
 cd ..
-mvn clean install -Djetty.test.image=$imageUnderTest -DskipTests --batch-mode
+mvn clean install -Djetty.test.image=$imageUnderTest -P-test.local -DskipTests --batch-mode
 popd
 
 # build app container locally

--- a/scripts/local_integration_test.sh
+++ b/scripts/local_integration_test.sh
@@ -35,7 +35,8 @@ fi
 
 # build the test app
 pushd ${testAppDir}
-mvn clean install -Djetty.test.image=$imageUnderTest
+cd ..
+mvn clean install -Djetty.test.image=$imageUnderTest -DskipTests
 popd
 
 # build app container locally
@@ -47,17 +48,30 @@ docker build -t $APP_IMAGE .
 echo "Starting app container..."
 docker run --rm --name $CONTAINER -e "SHUTDOWN_LOGGING_THREAD_DUMP=true" -e "SHUTDOWN_LOGGING_HEAP_INFO=true" $APP_IMAGE &> $OUTPUT_FILE &
 
-timeout 10 grep -q 'Server: Started' <(tail -f $OUTPUT_FILE 2> /dev/null)
+function waitForOutput() {
+  found_output='false'
+  for run in {1..10}
+  do
+    grep "$1" $OUTPUT_FILE && found_output='true' && break
+    sleep 1
+  done
+
+  if [ "$found_output" == "false" ]; then
+    echo "did not match '$1' in '$OUTPUT_FILE'"
+  fi
+}
+
+waitForOutput 'Server: Started'
 
 docker stop $CONTAINER
 
 docker rmi $APP_IMAGE
 
 echo 'verify thread dump'
-grep 'Full thread dump OpenJDK 64-Bit Server VM' $OUTPUT_FILE &> /dev/null
+waitForOutput 'Full thread dump OpenJDK 64-Bit Server VM'
 
 echo 'verify heap info'
-grep 'num.*instances.*bytes.*class name' $OUTPUT_FILE &> /dev/null
+waitForOutput 'num.*instances.*bytes.*class name'
 
 popd
 

--- a/scripts/local_integration_test.sh
+++ b/scripts/local_integration_test.sh
@@ -36,13 +36,13 @@ fi
 # build the test app
 pushd ${testAppDir}
 cd ..
-mvn clean install -Djetty.test.image=$imageUnderTest -DskipTests
+mvn clean install -Djetty.test.image=$imageUnderTest -DskipTests --batch-mode
 popd
 
 # build app container locally
 pushd $deployDir
 echo "Building app container..."
-docker build -t $APP_IMAGE .
+docker build -t $APP_IMAGE . || gcloud docker -- build -t $APP_IMAGE .
 
 # run app container locally to test shutdown logging
 echo "Starting app container..."

--- a/scripts/local_integration_test.sh
+++ b/scripts/local_integration_test.sh
@@ -58,6 +58,7 @@ function waitForOutput() {
 
   if [ "$found_output" == "false" ]; then
     echo "did not match '$1' in '$OUTPUT_FILE'"
+    exit 1
   fi
 }
 


### PR DESCRIPTION
The following tasks are pending before this test will pass
- [x] Release new openjdk image
- [x] Update openjdk image in pom.xml

Related to GoogleCloudPlatform/openjdk-runtime/pull/115