### PR TITLE
Specify jetty project in logging api construction

### DIFF
--- a/tests/test-war-smoke/src/test/java/com/google/cloud/runtimes/jetty/test/smoke/LoggingIntegrationTest.java
+++ b/tests/test-war-smoke/src/test/java/com/google/cloud/runtimes/jetty/test/smoke/LoggingIntegrationTest.java
@@ -67,7 +67,9 @@ public class LoggingIntegrationTest extends AbstractIntegrationTest {
     // wait for logs to propagate
     Thread.sleep(10 * 1000);
 
-    LoggingOptions options = LoggingOptions.getDefaultInstance();
+    LoggingOptions options = LoggingOptions.newBuilder()
+        .setProjectId(System.getProperty("app.deploy.project"))
+        .build();
 
     String moduleId = System.getProperty("app.deploy.service");
     String filter =


### PR DESCRIPTION
This is necessary for building when multiple projects are required.