### PR TITLE
Specify GKE zone

### DIFF
--- a/build/scripts/gke/create.sh
+++ b/build/scripts/gke/create.sh
@@ -16,5 +16,5 @@
 
 TEST_CLUSTER_EXISTENCE=$(gcloud container clusters list --project=${GCP_PROJECT} | awk "/$CLUSTER_NAME/")
 if [ -z "$TEST_CLUSTER_EXISTENCE" ]; then
-  gcloud container clusters create "$CLUSTER_NAME" --num-nodes=1 --disk-size=10 --project=${GCP_PROJECT}
+  gcloud container clusters create "$CLUSTER_NAME" --num-nodes=1 --disk-size=10 --project=${GCP_PROJECT} --zone=us-east1-b
 fi

--- a/build/scripts/gke/wait.sh
+++ b/build/scripts/gke/wait.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-gcloud container clusters get-credentials ${CLUSTER_NAME} --project=${GCP_PROJECT}
+gcloud container clusters get-credentials ${CLUSTER_NAME} --project=${GCP_PROJECT} --zone=us-east1-b
 
 echo "Waiting for the load balancer to be accessible (expected time: ~1min)"
 DEPLOYED_APP_IP=""


### PR DESCRIPTION
Container Builder builds are failing because this gcloud configuration property was not provided.

Thanks @cassand for figuring this out!