### PR TITLE
Specify gke zone, run scripts in strict mode

### DIFF
--- a/build/scripts/gke/create.sh
+++ b/build/scripts/gke/create.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 TEST_CLUSTER_EXISTENCE=$(gcloud container clusters list --project=${GCP_PROJECT} | awk "/$CLUSTER_NAME/")
 if [ -z "$TEST_CLUSTER_EXISTENCE" ]; then
   gcloud container clusters create "$CLUSTER_NAME" --num-nodes=1 --disk-size=10 --project=${GCP_PROJECT} --zone=us-east1-b

--- a/build/scripts/gke/deploy.sh
+++ b/build/scripts/gke/deploy.sh
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-gcloud container clusters get-credentials ${CLUSTER_NAME} --project=${GCP_PROJECT}
+set -e
+
+gcloud container clusters get-credentials ${CLUSTER_NAME} --project=${GCP_PROJECT} --zone=us-east1-b
 
 kubectl run ${GKE_TEST_APPLICATION} --image=${STAGING_IMAGE} --port=8080 --expose=true \
             --service-overrides='{ "apiVersion": "v1", "spec": { "type":  "LoadBalancer" } }' \

--- a/build/scripts/gke/test.sh
+++ b/build/scripts/gke/test.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 DEPLOYED_APP_URL=$(cat target/gke-app-ip.txt)
 
 /testsuite/driver.py --url=${DEPLOYED_APP_URL} $@

--- a/build/scripts/gke/wait.sh
+++ b/build/scripts/gke/wait.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -e
+
 gcloud container clusters get-credentials ${CLUSTER_NAME} --project=${GCP_PROJECT} --zone=us-east1-b
 
 echo "Waiting for the load balancer to be accessible (expected time: ~1min)"


### PR DESCRIPTION
This is a followup to https://github.com/GoogleCloudPlatform/jetty-runtime/pull/202