### PR TITLE
Specify projectId for datastore API

### DIFF
--- a/tests/test-war-smoke/src/test/java/com/google/cloud/runtimes/jetty/test/smoke/RemoteSessionIntegrationTest.java
+++ b/tests/test-war-smoke/src/test/java/com/google/cloud/runtimes/jetty/test/smoke/RemoteSessionIntegrationTest.java
@@ -67,7 +67,10 @@ public class RemoteSessionIntegrationTest extends AbstractIntegrationTest {
 
   @Before
   public void setUp() throws Exception {
-    datastore = DatastoreOptions.getDefaultInstance().getService();
+    datastore = DatastoreOptions.newBuilder()
+        .setProjectId(System.getenv("app.deploy.project"))
+        .build()
+        .getService();
     keyFactory = datastore.newKeyFactory().setKind("GCloudSession");
     objectMapper = new ObjectMapper();
   }


### PR DESCRIPTION
Our release builds run the test driver in a separate GCP project from where the actual App Engine applications are deployed, confusing though it may be.

For this reason, we need to specify the projectId when connecting to the datastore API. 