### PR TITLE
Fix jetty integration build

### DIFF
--- a/build/Dockerfile.mvn-gcloud
+++ b/build/Dockerfile.mvn-gcloud
@@ -10,21 +10,15 @@ RUN apt-get -y update && \
 
     # Setup Google Cloud SDK (latest)
     mkdir -p /builder && \
-    wget -qO- https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz | tar zxv -C /builder && \
+    wget -qO- "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz" | tar zxv -C /builder && \
     CLOUDSDK_PYTHON="python2.7" /builder/google-cloud-sdk/install.sh \
         --usage-reporting=false \
         --bash-completion=false \
         --disable-installation-options && \
 
-    /builder/google-cloud-sdk/bin/gcloud components update --version "${CLOUD_SDK_VERSION}" && \
     /builder/google-cloud-sdk/bin/gcloud config set component_manager/disable_update_check 1 && \
 
-    # Clean up
-    apt-get -y remove gcc python-dev python-setuptools wget && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf ~/.config/gcloud && \
-
-    # Kubernetes
+    # Kubernetes configuration
     /builder/google-cloud-sdk/bin/gcloud config set compute/zone us-east1-b && \
     /builder/google-cloud-sdk/bin/gcloud components install kubectl -q
 

--- a/tests/test-war-smoke/src/test/java/com/google/cloud/runtimes/jetty/test/smoke/RemoteSessionIntegrationTest.java
+++ b/tests/test-war-smoke/src/test/java/com/google/cloud/runtimes/jetty/test/smoke/RemoteSessionIntegrationTest.java
@@ -68,7 +68,7 @@ public class RemoteSessionIntegrationTest extends AbstractIntegrationTest {
   @Before
   public void setUp() throws Exception {
     datastore = DatastoreOptions.newBuilder()
-        .setProjectId(System.getenv("app.deploy.project"))
+        .setProjectId(System.getProperty("app.deploy.project"))
         .build()
         .getService();
     keyFactory = datastore.newKeyFactory().setKind("GCloudSession");


### PR DESCRIPTION
Silly mistake was causing the build to fail in a multi-project environment. Maven properties are provided as system properties, not as environment variables.

I also made a few enhancements to speed up the build of the mvn-gcloud test image, which should shave ~1 minute off the total build time. 