### PR TITLE
Re-enable health checks

### DIFF
--- a/tests/runtimes-common-testing/src/main/resources/app.yaml
+++ b/tests/runtimes-common-testing/src/main/resources/app.yaml
@@ -2,8 +2,5 @@ runtime: custom
 env: flex
 service: ${int.test.service}
 
-health_check:
-  enable_health_check: False
-
 manual_scaling:
   instances: 1

--- a/tests/test-war-smoke/src/main/appengine/app.yaml
+++ b/tests/test-war-smoke/src/main/appengine/app.yaml
@@ -2,9 +2,6 @@ runtime: custom
 env: flex
 service: ${app.deploy.service}
 
-health_check:
-  enable_health_check: False
-
 manual_scaling:
   instances: 1
 


### PR DESCRIPTION
Health checks should remain enabled for our App Engine integration test apps.