### PR TITLE
Remove logger re-entrance safeguard from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,11 +200,10 @@ docker run -it --rm \
 ### Enhanced Stackdriver Logging (BETA)
 When running on the Google Cloud Platform Flex environment, the Java Util Logging can be configured to send logs to Google Stackdriver Logging by providing a `logging.properties` file that configures a [LoggingHandler](http://googlecloudplatform.github.io/google-cloud-java/0.10.0/apidocs/com/google/cloud/logging/LoggingHandler.html) as follows:
 ```
-.level=INFO
-io.grpc.netty.level=INFO
-sun.net.level=INFO
-
 handlers=com.google.cloud.logging.LoggingHandler
+
+# Optional configuration
+.level=INFO
 com.google.cloud.logging.LoggingHandler.level=FINE
 com.google.cloud.logging.LoggingHandler.log=gae_app.log
 com.google.cloud.logging.LoggingHandler.formatter=java.util.logging.SimpleFormatter

--- a/tests/README.md
+++ b/tests/README.md
@@ -78,7 +78,7 @@ Remote testing is disabled by default but can be enabled to work in conjunction 
 From the base `jetty-runtime` directory:
 
 ```
-> mvn install -Ptest.remote,test.remote.deploy,test.remote.clean
+> mvn install -Ptest.remote,test.remote.deploy,test.remote.clean -Dapp.deploy.service=smoke
 ```
 
 This will activate the remote testing profile. Under this scenario, for each test artifact the `appengine-maven-plugin` is used to deploy an instance of the application to the Google Flexible environment and then run appropriate test cases.  The containers for each webapp will be built through using the cloud builder mechanism available in GCP.  This means the image to be tested (as referenced in the jetty.test.image property) will need to be deployed to the appropriate gcr.io location.  Remote testing can make use of the entire scope of services available to Google Flex.  
@@ -94,7 +94,7 @@ Note: should the build fail a remote deployed artifact may remain deployed and n
 Remote testing can also be run from the `jetty-runtime/tests` directory, but must explicitly define which remote image to use:
 
 ```
-> mvn install -Ptest.remote -Djetty.test.image=gcr.io/{project}/{container}:{tag}
+> mvn install -Ptest.remote -Djetty.test.image=gcr.io/{project}/{container}:{tag} -Dapp.deploy.service=smoke
 ```
 
 Test Case Requirements and Conventions

--- a/tests/test-war-smoke/src/main/webapp/WEB-INF/logging.properties
+++ b/tests/test-war-smoke/src/main/webapp/WEB-INF/logging.properties
@@ -1,9 +1,7 @@
+handlers=com.google.cloud.logging.LoggingHandler
+
 .level=INFO
 org.eclipse.jetty.http.level=INFO
-io.grpc.netty.level=INFO
-sun.net.level=INFO
-
-handlers=com.google.cloud.logging.LoggingHandler
 com.google.cloud.logging.LoggingHandler.level=FINE
 com.google.cloud.logging.LoggingHandler.log=gae_app.log
 com.google.cloud.logging.LoggingHandler.formatter=java.util.logging.SimpleFormatter


### PR DESCRIPTION
Re-entrance safeguards are no longer needed after https://github.com/GoogleCloudPlatform/google-cloud-java/pull/1523.

Update docs and the test app.