### PR TITLE
Env var for exploded wars

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,16 @@ write the Dockerfile like this:
 
 ```dockerfile
 FROM launcher.gcr.io/google/jetty
-ADD your-application.war $APP_DESTINATION
+ADD your-application.war $APP_DESTINATION_WAR
 ```
  
 That will add the WAR in the correct location for the Docker container.
+
+You can also use exploded-war artifacts:
+
+```dockerfile
+ADD your-application $APP_DESTINATION_EXPLODED_WAR
+```
 
 Once you have this configuration, you can use the Google Cloud SDK to deploy this directory containing the 2 configuration files and the WAR using:
 ```
@@ -97,9 +103,9 @@ For other Docker hosts, you'll need to create a Dockerfile based on this image t
 
 ```dockerfile
 FROM launcher.gcr.io/google/jetty
-COPY your-application.war $APP_DESTINATION
+COPY your-application.war $APP_DESTINATION_WAR
 ```
-You can then build the docker container using `docker build` or [Google Cloud Container Builder](https://cloud.google.com/container-builder/docs/).
+If your artifact is an exploded-war, then use the `APP_DESTINATION_EXPLODED_WAR` environment variable instead. You can then build the docker container using `docker build` or [Google Cloud Container Builder](https://cloud.google.com/container-builder/docs/).
 By default, the CMD is set to start the Jetty server. You can change this by specifying your own `CMD` or `ENTRYPOINT`.
 
 ## Entry Point Features
@@ -246,8 +252,14 @@ A standard war file may be deployed as the root context in an extended image by 
 in the docker build directory and using a `Dockerfile` like:
 ```dockerfile
 FROM launcher.gcr.io/google/jetty
-COPY your-application.war $APP_DESTINATION
+COPY your-application.war $APP_DESTINATION_WAR
 ```
+
+An exploded-war can also be used:
+```dockerfile
+COPY your-application $APP_DESTINATION_EXPLODED_WAR
+```
+
 
 ### Adding the root application to an image
 If the application exists as directory (i.e. an expanded war file), then directory must

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -47,7 +47,11 @@ RUN mkdir -p webapps $TMPDIR \
  && chmod +x /scripts/jetty/generate-jetty-start.sh
 
 # Set path where apps should be added to the container
-ENV APP_DESTINATION $JETTY_BASE/webapps/root.war
+ENV APP_WAR root.war
+ENV APP_EXPLODED_WAR root/
+ENV APP_DESTINATION $JETTY_BASE/webapps/
+ENV APP_DESTINATION_WAR $APP_DESTINATION$APP_WAR
+ENV APP_DESTINATION_EXPLODED_WAR $APP_DESTINATION$APP_EXPLODED_WAR
 
 EXPOSE 8080
 CMD ["java","-Djetty.base=${jetty.base}","-jar","${jetty.home}/start.jar"]

--- a/jetty9/src/main/docker/Dockerfile
+++ b/jetty9/src/main/docker/Dockerfile
@@ -49,9 +49,12 @@ RUN mkdir -p webapps $TMPDIR \
 # Set path where apps should be added to the container
 ENV APP_WAR root.war
 ENV APP_EXPLODED_WAR root/
-ENV APP_DESTINATION $JETTY_BASE/webapps/
-ENV APP_DESTINATION_WAR $APP_DESTINATION$APP_WAR
-ENV APP_DESTINATION_EXPLODED_WAR $APP_DESTINATION$APP_EXPLODED_WAR
+ENV APP_DESTINATION_PATH $JETTY_BASE/webapps/
+ENV APP_DESTINATION_WAR $APP_DESTINATION_PATH$APP_WAR
+ENV APP_DESTINATION_EXPLODED_WAR $APP_DESTINATION_PATH$APP_EXPLODED_WAR
+
+# This env var is here to not break users of previous versions where only a .war was expected
+ENV APP_DESTINATION $APP_DESTINATION_WAR
 
 EXPOSE 8080
 CMD ["java","-Djetty.base=${jetty.base}","-jar","${jetty.home}/start.jar"]

--- a/jetty9/src/test/resources/structure.yaml
+++ b/jetty9/src/test/resources/structure.yaml
@@ -56,7 +56,19 @@ commandTests:
   exitCode: 0
 - name: 'APP_DESTINATION is set'
   command: ['env']
-  expectedOutput: ['APP_DESTINATION=/var/lib/jetty/webapps/root.war']
+  expectedOutput: ['APP_DESTINATION=/var/lib/jetty/webapps/']
+- name: 'APP_WAR is set'
+  command: ['env']
+  expectedOutput: ['APP_WAR=root.war']
+- name: 'APP_EXPLODED_WAR is set'
+  command: ['env']
+  expectedOutput: ['APP_EXPLODED_WAR=root/']
+- name: 'APP_DESTINATION_WAR is set'
+  command: ['env']
+  expectedOutput: ['APP_DESTINATION_WAR=/var/lib/jetty/webapps/root.war']
+- name: 'APP_DESTINATION_EXPLODED_WAR is set'
+  command: ['env']
+  expectedOutput: ['APP_DESTINATION_EXPLODED_WAR=/var/lib/jetty/webapps/root/']
 
 fileExistenceTests:
 - name: 'jetty start.jar exists'

--- a/jetty9/src/test/resources/structure.yaml
+++ b/jetty9/src/test/resources/structure.yaml
@@ -54,9 +54,9 @@ commandTests:
   command: ['/workspace/jetty9/src/test/workspace/jetty-setup-dry-run.bash']
   expectedOutput: ['OK']
   exitCode: 0
-- name: 'APP_DESTINATION is set'
+- name: 'APP_DESTINATION_PATH is set'
   command: ['env']
-  expectedOutput: ['APP_DESTINATION=/var/lib/jetty/webapps/']
+  expectedOutput: ['APP_DESTINATION_PATH=/var/lib/jetty/webapps/']
 - name: 'APP_WAR is set'
   command: ['env']
   expectedOutput: ['APP_WAR=root.war']
@@ -66,6 +66,9 @@ commandTests:
 - name: 'APP_DESTINATION_WAR is set'
   command: ['env']
   expectedOutput: ['APP_DESTINATION_WAR=/var/lib/jetty/webapps/root.war']
+- name: 'APP_DESTINATION is set'
+  command: ['env']
+  expectedOutput: ['APP_DESTINATION=/var/lib/jetty/webapps/root.war']
 - name: 'APP_DESTINATION_EXPLODED_WAR is set'
   command: ['env']
   expectedOutput: ['APP_DESTINATION_EXPLODED_WAR=/var/lib/jetty/webapps/root/']


### PR DESCRIPTION
Existing 50-jetty.bash already takes care of unzipping root.war only if exploded war root directory doesn't already exist and is older than root.war. 

So all this PR needs to do is expose some env variables that the runtime builder can later use to add a COPY command to put the exploded-war in the correct place. 