### PR TITLE
Updated Jetty to v20170914

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <gcloud.api.version>1.0.1</gcloud.api.version>
     <jetty9.minor.version>4</jetty9.minor.version>
     <jetty9.dot.version>5</jetty9.dot.version>
-    <jetty9.version>9.${jetty9.minor.version}.${jetty9.dot.version}.v20170502</jetty9.version>
+    <jetty9.version>9.${jetty9.minor.version}.${jetty9.dot.version}.v20170914</jetty9.version>
     <docker.tag.prefix></docker.tag.prefix>
     <docker.tag.short>${docker.tag.prefix}9.${jetty9.minor.version}</docker.tag.short>
     <docker.tag.long>${docker.tag.prefix}9.${jetty9.minor.version}-${maven.build.timestamp}</docker.tag.long>


### PR DESCRIPTION
v20170502 is incompatible with Struts2 2.5.14 framework.  This incompatibility is reflected as a Server 500 error for static resource files.