### PR TITLE
Update openjdk image to always use latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <docker.tag.prefix></docker.tag.prefix>
     <docker.tag.short>${docker.tag.prefix}9.${jetty9.minor.version}</docker.tag.short>
     <docker.tag.long>${docker.tag.prefix}9.${jetty9.minor.version}-${maven.build.timestamp}</docker.tag.long>
-    <docker.openjdk.image>gcr.io/google-appengine/openjdk:8-2017-12-21_20_42</docker.openjdk.image>
+    <docker.openjdk.image>gcr.io/google-appengine/openjdk:8</docker.openjdk.image>
   </properties>
 
   <licenses>


### PR DESCRIPTION
As discussed to streamline the release process of this image.