### PR TITLE
Fix logging integration test

### DIFF
--- a/tests/test-war-smoke/src/test/java/com/google/cloud/runtimes/jetty/test/smoke/LoggingIntegrationTest.java
+++ b/tests/test-war-smoke/src/test/java/com/google/cloud/runtimes/jetty/test/smoke/LoggingIntegrationTest.java
@@ -85,7 +85,7 @@ public class LoggingIntegrationTest extends AbstractIntegrationTest {
           assertThat(entry.getResource().getType(), is("gae_app"));
           assertThat(entry.getResource().getLabels().get("module_id"), is(moduleId));
           assertThat(entry.getResource().getLabels().get("zone"), Matchers.notNullValue());
-          assertThat(entry.getLabels().get("appengine.googleapis.com/trace_id"), is(traceId));
+          assertThat(entry.getTrace(), is(traceId));
           assertThat(entry.getLabels().get("appengine.googleapis.com/instance_name"),
               Matchers.notNullValue());
 


### PR DESCRIPTION
The test now verifies that the trace id is stored
in the LogEntry.trace property.

Fixes #238.