### PR TITLE
upgrade to 9.4.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     <maven.build.timestamp.format>yyyy-MM-dd-HH-mm</maven.build.timestamp.format>
     <gcloud.api.bom.version>0.84.0-alpha</gcloud.api.bom.version>
     <jetty9.minor.version>4</jetty9.minor.version>
-    <jetty9.dot.version>23</jetty9.dot.version>
-    <jetty9.version>9.${jetty9.minor.version}.${jetty9.dot.version}.v20191118</jetty9.version>
+    <jetty9.dot.version>24</jetty9.dot.version>
+    <jetty9.version>9.${jetty9.minor.version}.${jetty9.dot.version}.v20191120</jetty9.version>
     <docker.tag.prefix></docker.tag.prefix>
     <docker.tag.short>${docker.tag.prefix}9.${jetty9.minor.version}</docker.tag.short>
     <docker.tag.long>${docker.tag.prefix}9.${jetty9.minor.version}-${maven.build.timestamp}</docker.tag.long>


### PR DESCRIPTION
Unfortunately there was a XSS vulnerability in 9.4.23.

```
jetty-9.4.24.v20191120 - 20 November 2019
 + 3083 The ini-template for jetty.console-capture.dir does not match the
   default value
 + 4128 OpenIdCredetials can't decode JWT ID token
 + 4334 Better test ErrorHandler changes
```

Signed-off-by: Greg Wilkins <gregw@webtide.com>