### PR TITLE
Bump Jetty to version 9.4.38.v20210224

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
     <maven.build.timestamp.format>yyyy-MM-dd-HH-mm</maven.build.timestamp.format>
     <gcloud.api.bom.version>0.133.0</gcloud.api.bom.version>
     <jetty9.minor.version>4</jetty9.minor.version>
-    <jetty9.dot.version>35</jetty9.dot.version>
-    <jetty9.version>9.${jetty9.minor.version}.${jetty9.dot.version}.v20201120</jetty9.version>
+    <jetty9.dot.version>38</jetty9.dot.version>
+    <jetty9.version>9.${jetty9.minor.version}.${jetty9.dot.version}.v20210224</jetty9.version>
     <docker.tag.prefix></docker.tag.prefix>
     <docker.tag.short>${docker.tag.prefix}9.${jetty9.minor.version}</docker.tag.short>
     <docker.tag.long>${docker.tag.prefix}9.${jetty9.minor.version}-${maven.build.timestamp}</docker.tag.long>


### PR DESCRIPTION
jetty-9.4.38.v20210224 - 24 February 2021

 + 4275 Path Normalization/Traversal - Context Matching
 + 5963 Improve QuotedQualityCSV for CVE-2020-27223
 + 5977 Cache-Control header set by a filter is override by the value from DefaultServlet configuration
 + 5994 QueuedThreadPool "free" threads
 + 5999 HttpURI ArrayIndexOutOfBounds
 + 6001 Ambiguous URI legacy compliance mode

jetty-9.4.37.v20210219 - 19 February 2021

 + 4275 Path Normalization/Traversal - Context Matching
 + 5492 Add ability to manage start modules by java feature
 + 5605 Blocked IO Thread not woken
 + 5787 Make ManagedSelector report better JMX data
 + 5851 org.eclipse.jetty.websocket.servlet.WebSocketServlet cleanup
 + 5859 Classloader leaks from ShutdownThread and QueuedThreadPool
 + 5909 Cannot disable HTTP OPTIONS Method
 + 5937 Unnecessary blocking in ResourceService
 + 5950 Deadlock due to logging inside classloaders
 + 5973 Proxy client TLS authentication example
 + 5977 Cache-Control header set by a filter is override by the value from DefaultServlet configuration
 + 5979 Configurable gzip Etag extension

jetty-9.4.36.v20210114 - 14 January 2021

 + 5310 Jetty Http2 client discards the response fames when there is GOAWAY and sends RST_STREAM
 + 5499 Improve temporary buffer usage for WebSocket PerMessageDeflate
 + 5633 Allow to configure HttpClient request authority
 + 5689 Jetty ssl keystorePath doesn't work with absolute path
 + 5755 Cannot configure maxDynamicTableSize on HTTP2Client
 + 5783 Fix ConnectionStatistics.*Rate() methods
 + 5785 Reduce log level for WebSocket connections closed by clients
 + 5794 ServerConnector leaks closed sockets which can lead to file descriptor exhaustion
 + 5824 Build up of ConstraintMappings when stopping and starting WebAppContext
 + 5830 Jetty-util contains wrong Import-Package
 + 5844 download flag to jetty-start causes NullPointerException
 + 5845 Use UTF-8 encoding for client basic auth if requested
 + 5855 HttpClient may not send queued requests
 + 5870 jetty-maven-plugin fails to run ServletContainerInitializer on Windows due to URI case comparison bug
