### PR TITLE
Fix Maven test Dockerfile.

### DIFF
--- a/build/Dockerfile.mvn-gcloud.template
+++ b/build/Dockerfile.mvn-gcloud.template
@@ -3,18 +3,18 @@
 
 FROM maven:3.5.0-jdk-8
 
-ARG CLOUD_SDK_VERSION=305.0.0
+ARG CLOUD_SDK_VERSION=433.0.1
 
 # The zone will be substituted here by build.sh
 ARG GCP_ZONE=[INSERT_GCP_ZONE]
 
-RUN apt-get -y update && \
+RUN echo 'deb http://archive.debian.org/debian stretch main' > /etc/apt/sources.list && apt-get -y update && \
     apt-get -y install gcc python2.7 python-dev python-setuptools curl wget ca-certificates && \
 
     # Setup Google Cloud SDK (latest)
     mkdir -p /builder && \
     wget -qO- "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz" | tar zxv -C /builder && \
-    CLOUDSDK_PYTHON="python2.7" /builder/google-cloud-sdk/install.sh \
+    /builder/google-cloud-sdk/install.sh \
         --usage-reporting=false \
         --bash-completion=false \
         --disable-installation-options && \


### PR DESCRIPTION
Debian 9/stretch moved to archive.debian.org. 
Context - https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html Similar fix in OpenJDK - https://github.com/GoogleCloudPlatform/openjdk-runtime/commit/ded3c46e45318e2a099fce33af7a01c075f7b383

Also update the Cloud SDK version to the latest, and remove CLOUDSDK_PYTHON (previously set to 2.7) as Cloud SDK no longer supports Python 2.7.