### PR TITLE
Revert Google Cloud SDK upgrade in mvn-gcloud.

### DIFF
--- a/build/Dockerfile.mvn-gcloud.template
+++ b/build/Dockerfile.mvn-gcloud.template
@@ -3,7 +3,7 @@
 
 FROM maven:3.5.0-jdk-8
 
-ARG CLOUD_SDK_VERSION=433.0.1
+ARG CLOUD_SDK_VERSION=305.0.0
 
 # The zone will be substituted here by build.sh
 ARG GCP_ZONE=[INSERT_GCP_ZONE]


### PR DESCRIPTION
The latest version (upgraded in previous commit) requires Authentication to happen before any of the 'gcloud' commands are executed. This is currently incompatible with the way the mvn-gcloud Dockerfile is designed.